### PR TITLE
Simplify array initialisation

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -1,3 +1,4 @@
+import collections
 import numbers
 import struct
 import warnings
@@ -15,7 +16,7 @@ import ubermagutil.typesystem as ts
 
 @ts.typesystem(mesh=ts.Typed(expected_type=df.Mesh, const=True),
                dim=ts.Scalar(expected_type=int, positive=True, const=True))
-class Field:
+class Field(collections.abc.Callable):  # could be avoided by using type hints
     """Finite-difference field.
 
     This class specifies a finite-difference field and defines operations for

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -435,7 +435,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
 
             self.array /= self.norm.array  # normalise to 1
-            self.array *= dfu.as_array(val=val, self.mesh, dim=1,
+            self.array *= dfu.as_array(val, self.mesh, dim=1,
                                        dtype=self.dtype)
 
     def __abs__(self):

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -347,7 +347,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
     @array.setter
     def array(self, val):
-        self._array = dfu.as_array(self.mesh, self.dim, val)
+        self._array = dfu.as_array(self.mesh, self.dim, val, dtype=self.dtype)
 
     @property
     def norm(self):
@@ -435,7 +435,8 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
 
             self.array /= self.norm.array  # normalise to 1
-            self.array *= dfu.as_array(self.mesh, dim=1, val=val)
+            self.array *= dfu.as_array(self.mesh, dim=1, val=val,
+                                       dtype=self.dtype)
 
     def __abs__(self):
         """Field norm.

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -109,11 +109,13 @@ class Field:
 
     """
 
-    def __init__(self, mesh, dim, value=0, norm=None, components=None):
+    def __init__(self, mesh, dim, value=0, norm=None, components=None,
+                 dtype=np.float64):
         self.mesh = mesh
         self.dim = dim
         self.value = value
         self.norm = norm
+        self.dtype = dtype
 
         self._components = None  # required in here for correct initialisation
         self.components = components
@@ -243,7 +245,8 @@ class Field:
         .. seealso:: :py:func:`~discretisedfield.Field.array`
 
         """
-        value_array = dfu.as_array(self.mesh, self.dim, self._value)
+        value_array = dfu.as_array(self.mesh, self.dim, self._value,
+                                   dtype=self.dtype)
         if np.array_equal(self.array, value_array):
             return self._value
         else:
@@ -252,7 +255,7 @@ class Field:
     @value.setter
     def value(self, val):
         self._value = val
-        self.array = dfu.as_array(self.mesh, self.dim, val)
+        self.array = dfu.as_array(self.mesh, self.dim, val, dtype=self.dtype)
 
     @property
     def components(self):
@@ -3348,7 +3351,8 @@ class Field:
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components)
+                              components=self.components,
+                              dtype=np.complex128)
 
     @property
     def ifftn(self):
@@ -3369,7 +3373,8 @@ class Field:
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components)
+                              components=self.components,
+                              dtype=np.complex128)
 
     @property
     def rfftn(self):
@@ -3391,7 +3396,8 @@ class Field:
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components)
+                              components=self.components,
+                              dtype=np.complex128)
 
     @property
     def irfftn(self):
@@ -3415,7 +3421,8 @@ class Field:
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components)
+                              components=self.components,
+                              dtype=np.complex128)
 
     def _fft_mesh(self, rfft=False):
         """FFT can be one of fftfreq, rfftfreq."""
@@ -3482,7 +3489,8 @@ class Field:
         """Complex conjugate of complex field."""
         return self.__class__(self.mesh, dim=self.dim,
                               value=self.array.conjugate(),
-                              components=self.components)
+                              components=self.components,
+                              dtype=np.complex128)
 
     # TODO check and write tests
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -113,12 +113,14 @@ class Field:
                  dtype=np.float64):
         self.mesh = mesh
         self.dim = dim
-        self.value = value
-        self.norm = norm
         self.dtype = dtype
 
+        # order in here is important to avoid infinite recursion
         self._components = None  # required in here for correct initialisation
         self.components = components
+
+        self.value = value
+        self.norm = norm
 
     @property
     def value(self):

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -248,7 +248,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         .. seealso:: :py:func:`~discretisedfield.Field.array`
 
         """
-        value_array = dfu.as_array(self.mesh, self.dim, self._value,
+        value_array = dfu.as_array(self._value, self.mesh, self.dim,
                                    dtype=self.dtype)
         if np.array_equal(self.array, value_array):
             return self._value
@@ -258,7 +258,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
     @value.setter
     def value(self, val):
         self._value = val
-        self.array = dfu.as_array(self.mesh, self.dim, val, dtype=self.dtype)
+        self.array = dfu.as_array(val, self.mesh, self.dim, dtype=self.dtype)
 
     @property
     def components(self):
@@ -347,7 +347,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
     @array.setter
     def array(self, val):
-        self._array = dfu.as_array(self.mesh, self.dim, val, dtype=self.dtype)
+        self._array = dfu.as_array(val, self.mesh, self.dim, dtype=self.dtype)
 
     @property
     def norm(self):
@@ -435,7 +435,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
 
             self.array /= self.norm.array  # normalise to 1
-            self.array *= dfu.as_array(self.mesh, dim=1, val=val,
+            self.array *= dfu.as_array(val=val, self.mesh, dim=1,
                                        dtype=self.dtype)
 
     def __abs__(self):

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -553,7 +553,7 @@ class Field:
                                       out=np.zeros_like(self.array),
                                       where=(self.norm.array != 0))
         return self.__class__(self.mesh, dim=self.dim, value=orientation_array,
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     @property
     def average(self):
@@ -743,7 +743,8 @@ class Field:
         if self.components is not None and attr in self.components:
             attr_array = self.array[..., self.components.index(attr),
                                     np.newaxis]
-            return self.__class__(mesh=self.mesh, dim=1, value=attr_array)
+            return self.__class__(mesh=self.mesh, dim=1, value=attr_array,
+                                  dtype=self.dtype)
         else:
             msg = f'Object has no attribute {attr}.'
             raise AttributeError(msg)
@@ -1095,7 +1096,7 @@ class Field:
 
         return self.__class__(self.mesh, dim=1,
                               value=np.power(self.array, other),
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     def __add__(self, other):
         """Binary ``+`` operator.
@@ -1166,9 +1167,11 @@ class Field:
                        'defined on different meshes.')
                 raise ValueError(msg)
         elif self.dim == 1 and isinstance(other, numbers.Real):
-            return self + self.__class__(self.mesh, dim=self.dim, value=other)
+            return self + self.__class__(self.mesh, dim=self.dim, value=other,
+                                         dtype=self.dtype)
         elif self.dim == 3 and isinstance(other, (tuple, list, np.ndarray)):
-            return self + self.__class__(self.mesh, dim=self.dim, value=other)
+            return self + self.__class__(self.mesh, dim=self.dim, value=other,
+                                         dtype=self.dtype)
         else:
             msg = (f'Unsupported operand type(s) for +: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1176,7 +1179,7 @@ class Field:
 
         return self.__class__(self.mesh, dim=self.dim,
                               value=self.array + other.array,
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     def __radd__(self, other):
         return self + other
@@ -1322,11 +1325,12 @@ class Field:
                        'defined on different meshes.')
                 raise ValueError(msg)
         elif isinstance(other, numbers.Complex):
-            return self * self.__class__(self.mesh, dim=1, value=other)
+            return self * self.__class__(self.mesh, dim=1, value=other,
+                                         dtype=self.dtype)
         elif self.dim == 1 and isinstance(other, (tuple, list, np.ndarray)):
             return self * self.__class__(self.mesh,
                                          dim=np.array(other).shape[-1],
-                                         value=other)
+                                         value=other, dtype=self.dtype)
         elif isinstance(other, df.DValue):
             return self * other(self)
         else:
@@ -1339,7 +1343,7 @@ class Field:
             else None
         return self.__class__(self.mesh, dim=res_array.shape[-1],
                               value=res_array,
-                              components=components)
+                              components=components, dtype=self.dtype)
 
     def __rmul__(self, other):
         return self * other
@@ -1466,7 +1470,8 @@ class Field:
                 raise ValueError(msg)
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self @ self.__class__(self.mesh, dim=3, value=other,
-                                         components=self.components)
+                                         components=self.components,
+                                         dtype=self.dtype)
         elif isinstance(other, df.DValue):
             return self @ other(self)
         else:
@@ -1534,7 +1539,8 @@ class Field:
                 raise ValueError(msg)
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self & self.__class__(self.mesh, dim=3, value=other,
-                                         components=self.components)
+                                         components=self.components,
+                                         dtype=self.dtype)
         else:
             msg = (f'Unsupported operand type(s) for &: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1542,7 +1548,7 @@ class Field:
 
         res_array = np.cross(self.array, other.array)
         return self.__class__(self.mesh, dim=3, value=res_array,
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     def __rand__(self, other):
         return self & other
@@ -1609,10 +1615,11 @@ class Field:
                        'defined on different meshes.')
                 raise ValueError(msg)
         elif isinstance(other, numbers.Real):
-            return self << self.__class__(self.mesh, dim=1, value=other)
+            return self << self.__class__(self.mesh, dim=1, value=other,
+                                          dtype=self.dtype)
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self << self.__class__(self.mesh, dim=len(other),
-                                          value=other)
+                                          value=other, dtype=self.dtype)
         else:
             msg = (f'Unsupported operand type(s) for <<: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1632,14 +1639,15 @@ class Field:
 
         return self.__class__(self.mesh, dim=len(array_list),
                               value=np.stack(array_list, axis=3),
-                              components=components)
+                              components=components, dtype=self.dtype)
 
     def __rlshift__(self, other):
         if isinstance(other, numbers.Real):
-            return self.__class__(self.mesh, dim=1, value=other) << self
+            return self.__class__(self.mesh, dim=1, value=other,
+                                  dtype=self.dtype) << self
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self.__class__(self.mesh, dim=len(other),
-                                  value=other) << self
+                                  value=other, dtype=self.dtype) << self
         else:
             msg = (f'Unsupported operand type(s) for <<: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1708,7 +1716,7 @@ class Field:
         padded_mesh = self.mesh.pad(pad_width)
 
         return self.__class__(padded_mesh, dim=self.dim, value=padded_array,
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     def derivative(self, direction, n=1):
         """Directional derivative.
@@ -1861,7 +1869,7 @@ class Field:
                                          axis=direction)
 
         return self.__class__(self.mesh, dim=self.dim, value=derivative_array,
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     @property
     def grad(self):
@@ -2289,7 +2297,7 @@ class Field:
             res_array = np.cumsum(self.array, axis=dfu.axesdict[direction])
 
         res = self.__class__(mesh, dim=self.dim, value=res_array,
-                             components=self.components)
+                             components=self.components, dtype=self.dtype)
 
         if len(direction) == 3:
             return dfu.array2tuple(res.array.squeeze())
@@ -2403,7 +2411,7 @@ class Field:
         """
         plane_mesh = self.mesh.plane(*args, n=n, **kwargs)
         return self.__class__(plane_mesh, dim=self.dim, value=self,
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     def __getitem__(self, item):
         """Extracts the field on a subregion.
@@ -2482,7 +2490,7 @@ class Field:
         slices = [slice(i, j) for i, j in zip(index_min, index_max)]
         return self.__class__(submesh, dim=self.dim,
                               value=self.array[tuple(slices)],
-                              components=self.components)
+                              components=self.components, dtype=self.dtype)
 
     def project(self, direction):
         """Projects the field along one direction and averages it out along
@@ -2580,7 +2588,8 @@ class Field:
         angle_array[angle_array < 0] += 2 * np.pi
 
         return self.__class__(self.mesh, dim=1,
-                              value=angle_array[..., np.newaxis])
+                              value=angle_array[..., np.newaxis],
+                              dtype=self.dtype)
 
     def write(self, filename, representation='txt', extend_scalar=False):
         """Write the field to OVF, HDF5, or VTK file.
@@ -3492,7 +3501,7 @@ class Field:
         return self.__class__(self.mesh, dim=self.dim,
                               value=self.array.conjugate(),
                               components=self.components,
-                              dtype=np.complex128)
+                              dtype=self.dtype)
 
     # TODO check and write tests
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
@@ -3519,10 +3528,11 @@ class Field:
             if len(result) != len(mesh):
                 raise ValueError('wrong number of Field objects')
             return tuple(self.__class__(m, dim=x.shape[-1], value=x,
-                                        components=self.components)
+                                        components=self.components,
+                                        dtype=self.dtype)
                          for x, m in zip(result, mesh))
         elif method == 'at':
             return None
         else:
             return self.__class__(mesh[0], dim=result.shape[-1], value=result,
-                                  components=self.components)
+                                  components=self.components, dtype=self.dtype)

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -116,12 +116,11 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         self.dim = dim
         self.dtype = dtype
 
-        # order in here is important to avoid infinite recursion
-        self._components = None  # required in here for correct initialisation
-        self.components = components
-
         self.value = value
         self.norm = norm
+
+        self._components = None  # required in here for correct initialisation
+        self.components = components
 
     @property
     def value(self):

--- a/discretisedfield/field_rotator.py
+++ b/discretisedfield/field_rotator.py
@@ -167,7 +167,8 @@ class FieldRotator:
 
         self._rotated_field = df.Field(mesh=new_mesh,
                                        dim=self._orig_field.dim,
-                                       value=new_m)
+                                       value=new_m,
+                                       dtype=self._orig_field.dtype)
 
     def clear_rotation(self):
         """Remove all rotations."""

--- a/discretisedfield/tests/__init__.py
+++ b/discretisedfield/tests/__init__.py
@@ -1,0 +1,2 @@
+import matplotlib
+matplotlib.use('agg')

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -203,8 +203,13 @@ class TestField:
                 with pytest.raises((ValueError, TypeError)):
                     f = df.Field(mesh, dim=dim)
 
+        # wrong abc.Iterable
         with pytest.raises(ValueError):
             df.Field(self.meshes[0], dim=1, value='string')
+
+        # wrong type
+        with pytest.raises(TypeError):
+            df.Field(self.meshes[0], dim=1, value=True)
 
     def test_set_with_ndarray(self):
         for mesh in self.meshes:

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -207,9 +207,11 @@ class TestField:
         with pytest.raises(ValueError):
             df.Field(self.meshes[0], dim=1, value='string')
 
-        # wrong type
+        # all builtin types are numeric types or Iterable
+        class WrongType:
+            pass
         with pytest.raises(TypeError):
-            df.Field(self.meshes[0], dim=1, value=True)
+            df.Field(self.meshes[0], dim=1, value=WrongType())
 
     def test_set_with_ndarray(self):
         for mesh in self.meshes:

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -203,6 +203,9 @@ class TestField:
                 with pytest.raises((ValueError, TypeError)):
                     f = df.Field(mesh, dim=dim)
 
+        with pytest.raises(ValueError):
+            df.Field(self.meshes[0], dim=1, value='string')
+
     def test_set_with_ndarray(self):
         for mesh in self.meshes:
             f = df.Field(mesh, dim=3)

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -37,8 +37,7 @@ def _(val, array, mesh, dim):
     return array
 
 
-@_fill_array.register(list)
-@_fill_array.register(tuple)
+@_fill_array.register(collections.abc.Iterable)
 def _(val, array, mesh, dim):
     if len(val) != dim:
         raise ValueError(f'Wrong dimension {len(val)} provided for value;'

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -20,7 +20,7 @@ def array2tuple(array):
 
 @functools.singledispatch
 def as_array(val, mesh, dim, dtype):
-    raise ValueError('Unsupported type {type(val)}.')
+    raise TypeError('Unsupported type {type(val)}.')
 
 
 @as_array.register(numbers.Complex)

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -18,7 +18,7 @@ def array2tuple(array):
     return array.item() if array.size == 1 else tuple(array.tolist())
 
 
-def as_array(mesh, dim, val, dtype=np.float64):
+def as_array(mesh, dim, val, dtype):
     array = np.empty((*mesh.n, dim), dtype=dtype)
     return _fill_array(val, array, mesh, dim)
 

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -20,8 +20,7 @@ def array2tuple(array):
 
 def as_array(mesh, dim, val, dtype=np.float64):
     array = np.empty((*mesh.n, dim), dtype=dtype)
-    _fill_array(val, array, mesh, dim)
-    return array
+    return _fill_array(val, array, mesh, dim)
 
 
 @functools.singledispatch
@@ -36,6 +35,7 @@ def _(val, array, mesh, dim):
         raise ValueError('Wrong dimension 1 provided for value;'
                          f' expected dimension is {dim}')
     array.fill(val)
+    return array
 
 
 @_fill_array.register(list)
@@ -45,6 +45,7 @@ def _(val, array, mesh, dim):
         raise ValueError(f'Wrong dimension {len(val)} provided for value;'
                          f' expected dimension is {dim}')
     array[..., :] = val
+    return array
 
 
 @_fill_array.register(np.ndarray)
@@ -56,6 +57,7 @@ def _(val, array, mesh, dim):
     else:
         raise ValueError(f'Wrong shape {val.shape} provided for value;'
                          f' expected shape is {(*mesh.n, dim)} or {(dim,)}.')
+    return array
 
 
 @_fill_array.register(collections.abc.Callable)
@@ -63,6 +65,7 @@ def _(val, array, mesh, dim):
     for index, point in zip(mesh.indices, mesh):
         res = val(point)
         array[index] = res
+    return array
 
 
 @_fill_array.register(dict)
@@ -98,6 +101,7 @@ def _(val, array, mesh, dim):
                         + "contained within one of the subregions, " \
                         + "key 'default' must be specified for value."
                 raise KeyError(msg)
+    return array
 
 
 def bergluescher_angle(v1, v2, v3):

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -30,7 +30,6 @@ def _fill_array(val, array, mesh, dim):
 
 @_fill_array.register(numbers.Complex)  # contains numbers.Real
 def _(val, array, mesh, dim):
-    # TODO why not allow uniform values for vector fields
     if dim > 1 and val != 0:
         raise ValueError('Wrong dimension 1 provided for value;'
                          f' expected dimension is {dim}')

--- a/docs/field-operations.ipynb
+++ b/docs/field-operations.ipynb
@@ -16,6 +16,7 @@
    "outputs": [],
    "source": [
     "import discretisedfield as df\n",
+    "import numpy as np\n",
     "\n",
     "p1 = (-50, -50, -50)\n",
     "p2 = (50, 50, 50)\n",
@@ -523,7 +524,7 @@
    "source": [
     "## 8. Complex fields\n",
     "\n",
-    "`discretisedfield` supports complex-valued fields."
+    "`discretisedfield` supports complex-valued fields. We have to manually pass the correct `dtype`."
    ]
   },
   {
@@ -532,7 +533,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cfield = df.Field(mesh, dim=3, value=(1+1.5j, 2, 3j))"
+    "cfield = df.Field(mesh, dim=3, value=(1+1.5j, 2, 3j), dtype=np.complex128)"
    ]
   },
   {
@@ -837,7 +838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Breaks `as_array` function into multiple smaller ones to simplify and make it more readable.

- [x] add `dtype` to all `Field(...)` and `Field.__class__(...)` calls
- [x] update tests