### PR TITLE
Automatically determine dtype for array_like inputs.

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -54,6 +54,13 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         Please refer to ``discretisedfield.Field.norm`` property. Defaults to
         ``None`` (``norm=None`` defines no norm).
 
+    dtype : str, type, np.dtype
+
+        Data type of the underlying numpy array. If not specified the best data
+        type is automatically determined if ``value`` is  array_like, for
+        callable and dict ``value`` the numpy default (currently
+        ``float64``) is used. Defaults to ``None``.
+
     Examples
     --------
     1. Defining a uniform three-dimensional vector field on a nano-sized thin
@@ -112,7 +119,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
     """
 
     def __init__(self, mesh, dim, value=0, norm=None, components=None,
-                 dtype=np.float64):
+                 dtype=None):
         self.mesh = mesh
         self.dim = dim
         self.dtype = dtype
@@ -248,7 +255,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         .. seealso:: :py:func:`~discretisedfield.Field.array`
 
         """
-        value_array = dfu.as_array(self._value, self.mesh, self.dim,
+        value_array = dfu.as_array(self._value, self.mesh, self.dim)
                                    dtype=self.dtype)
         if np.array_equal(self.array, value_array):
             return self._value
@@ -435,8 +442,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
 
             self.array /= self.norm.array  # normalise to 1
-            self.array *= dfu.as_array(val, self.mesh, dim=1,
-                                       dtype=self.dtype)
+            self.array *= dfu.as_array(val, self.mesh, dim=1)
 
     def __abs__(self):
         """Field norm.
@@ -552,10 +558,11 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         orientation_array = np.divide(self.array,
                                       self.norm.array,
+                                      # TODO why do we specify out
                                       out=np.zeros_like(self.array),
                                       where=(self.norm.array != 0))
         return self.__class__(self.mesh, dim=self.dim, value=orientation_array,
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     @property
     def average(self):
@@ -747,8 +754,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         if self.components is not None and attr in self.components:
             attr_array = self.array[..., self.components.index(attr),
                                     np.newaxis]
-            return self.__class__(mesh=self.mesh, dim=1, value=attr_array,
-                                  dtype=self.dtype)
+            return self.__class__(mesh=self.mesh, dim=1, value=attr_array)
         else:
             msg = f'Object has no attribute {attr}.'
             raise AttributeError(msg)
@@ -1100,7 +1106,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(self.mesh, dim=1,
                               value=np.power(self.array, other),
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     def __add__(self, other):
         """Binary ``+`` operator.
@@ -1170,12 +1176,10 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 msg = ('Cannot apply operator + on fields '
                        'defined on different meshes.')
                 raise ValueError(msg)
-        elif self.dim == 1 and isinstance(other, numbers.Real):
-            return self + self.__class__(self.mesh, dim=self.dim, value=other,
-                                         dtype=self.dtype)
+        elif self.dim == 1 and isinstance(other, numbers.Complex):
+            return self + self.__class__(self.mesh, dim=self.dim, value=other)
         elif self.dim == 3 and isinstance(other, (tuple, list, np.ndarray)):
-            return self + self.__class__(self.mesh, dim=self.dim, value=other,
-                                         dtype=self.dtype)
+            return self + self.__class__(self.mesh, dim=self.dim, value=other)
         else:
             msg = (f'Unsupported operand type(s) for +: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1183,7 +1187,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(self.mesh, dim=self.dim,
                               value=self.array + other.array,
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     def __radd__(self, other):
         return self + other
@@ -1329,12 +1333,11 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                        'defined on different meshes.')
                 raise ValueError(msg)
         elif isinstance(other, numbers.Complex):
-            return self * self.__class__(self.mesh, dim=1, value=other,
-                                         dtype=self.dtype)
+            return self * self.__class__(self.mesh, dim=1, value=other)
         elif self.dim == 1 and isinstance(other, (tuple, list, np.ndarray)):
             return self * self.__class__(self.mesh,
                                          dim=np.array(other).shape[-1],
-                                         value=other, dtype=self.dtype)
+                                         value=other)
         elif isinstance(other, df.DValue):
             return self * other(self)
         else:
@@ -1347,7 +1350,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
             else None
         return self.__class__(self.mesh, dim=res_array.shape[-1],
                               value=res_array,
-                              components=components, dtype=self.dtype)
+                              components=components)
 
     def __rmul__(self, other):
         return self * other
@@ -1474,8 +1477,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self @ self.__class__(self.mesh, dim=3, value=other,
-                                         components=self.components,
-                                         dtype=self.dtype)
+                                         components=self.components)
         elif isinstance(other, df.DValue):
             return self @ other(self)
         else:
@@ -1543,8 +1545,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self & self.__class__(self.mesh, dim=3, value=other,
-                                         components=self.components,
-                                         dtype=self.dtype)
+                                         components=self.components)
         else:
             msg = (f'Unsupported operand type(s) for &: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1552,7 +1553,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         res_array = np.cross(self.array, other.array)
         return self.__class__(self.mesh, dim=3, value=res_array,
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     def __rand__(self, other):
         return self & other
@@ -1618,12 +1619,11 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 msg = ('Cannot apply operator << on fields '
                        'defined on different meshes.')
                 raise ValueError(msg)
-        elif isinstance(other, numbers.Real):
-            return self << self.__class__(self.mesh, dim=1, value=other,
-                                          dtype=self.dtype)
+        elif isinstance(other, numbers.Complex):
+            return self << self.__class__(self.mesh, dim=1, value=other)
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self << self.__class__(self.mesh, dim=len(other),
-                                          value=other, dtype=self.dtype)
+                                          value=other)
         else:
             msg = (f'Unsupported operand type(s) for <<: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1643,15 +1643,14 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(self.mesh, dim=len(array_list),
                               value=np.stack(array_list, axis=3),
-                              components=components, dtype=self.dtype)
+                              components=components)
 
     def __rlshift__(self, other):
-        if isinstance(other, numbers.Real):
-            return self.__class__(self.mesh, dim=1, value=other,
-                                  dtype=self.dtype) << self
+        if isinstance(other, numbers.Complex):
+            return self.__class__(self.mesh, dim=1, value=other) << self
         elif isinstance(other, (tuple, list, np.ndarray)):
             return self.__class__(self.mesh, dim=len(other),
-                                  value=other, dtype=self.dtype) << self
+                                  value=other) << self
         else:
             msg = (f'Unsupported operand type(s) for <<: '
                    f'{type(self)=} and {type(other)=}.')
@@ -1720,7 +1719,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         padded_mesh = self.mesh.pad(pad_width)
 
         return self.__class__(padded_mesh, dim=self.dim, value=padded_array,
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     def derivative(self, direction, n=1):
         """Directional derivative.
@@ -1873,7 +1872,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                                          axis=direction)
 
         return self.__class__(self.mesh, dim=self.dim, value=derivative_array,
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     @property
     def grad(self):
@@ -2301,7 +2300,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
             res_array = np.cumsum(self.array, axis=dfu.axesdict[direction])
 
         res = self.__class__(mesh, dim=self.dim, value=res_array,
-                             components=self.components, dtype=self.dtype)
+                             components=self.components)
 
         if len(direction) == 3:
             return dfu.array2tuple(res.array.squeeze())
@@ -2415,7 +2414,9 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         """
         plane_mesh = self.mesh.plane(*args, n=n, **kwargs)
         return self.__class__(plane_mesh, dim=self.dim, value=self,
-                              components=self.components, dtype=self.dtype)
+                              components=self.components,
+                              dtype=self.array.dtype  # callable requires dtype
+                              )
 
     def __getitem__(self, item):
         """Extracts the field on a subregion.
@@ -2494,7 +2495,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         slices = [slice(i, j) for i, j in zip(index_min, index_max)]
         return self.__class__(submesh, dim=self.dim,
                               value=self.array[tuple(slices)],
-                              components=self.components, dtype=self.dtype)
+                              components=self.components)
 
     def project(self, direction):
         """Projects the field along one direction and averages it out along
@@ -2592,8 +2593,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         angle_array[angle_array < 0] += 2 * np.pi
 
         return self.__class__(self.mesh, dim=1,
-                              value=angle_array[..., np.newaxis],
-                              dtype=self.dtype)
+                              value=angle_array[..., np.newaxis])
 
     def write(self, filename, representation='txt', extend_scalar=False):
         """Write the field to OVF, HDF5, or VTK file.
@@ -3366,8 +3366,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components,
-                              dtype=np.complex128)
+                              components=self.components)
 
     @property
     def ifftn(self):
@@ -3388,8 +3387,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components,
-                              dtype=np.complex128)
+                              components=self.components)
 
     @property
     def rfftn(self):
@@ -3411,8 +3409,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components,
-                              dtype=np.complex128)
+                              components=self.components)
 
     @property
     def irfftn(self):
@@ -3436,8 +3433,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         return self.__class__(mesh, dim=len(values),
                               value=np.stack(values, axis=3),
-                              components=self.components,
-                              dtype=np.complex128)
+                              components=self.components)
 
     def _fft_mesh(self, rfft=False):
         """FFT can be one of fftfreq, rfftfreq."""
@@ -3504,8 +3500,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         """Complex conjugate of complex field."""
         return self.__class__(self.mesh, dim=self.dim,
                               value=self.array.conjugate(),
-                              components=self.components,
-                              dtype=self.dtype)
+                              components=self.components)
 
     # TODO check and write tests
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
@@ -3532,11 +3527,10 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
             if len(result) != len(mesh):
                 raise ValueError('wrong number of Field objects')
             return tuple(self.__class__(m, dim=x.shape[-1], value=x,
-                                        components=self.components,
-                                        dtype=self.dtype)
+                                        components=self.components)
                          for x, m in zip(result, mesh))
         elif method == 'at':
             return None
         else:
             return self.__class__(mesh[0], dim=result.shape[-1], value=result,
-                                  components=self.components, dtype=self.dtype)
+                                  components=self.components)

--- a/discretisedfield/field_rotator.py
+++ b/discretisedfield/field_rotator.py
@@ -169,8 +169,7 @@ class FieldRotator:
 
         self._rotated_field = df.Field(mesh=new_mesh,
                                        dim=self._orig_field.dim,
-                                       value=new_m,
-                                       dtype=self._orig_field.dtype)
+                                       value=new_m)
 
     def clear_rotation(self):
         """Remove all rotations."""

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -139,23 +139,24 @@ class TestField:
             self.meshes.append(mesh)
 
         # Create lists of field values.
-        self.consts = [[0, np.float64],
-                       [-5., np.float64],
-                       [np.pi, np.float64],
-                       [1e-15, np.float64],
-                       [1.2e12, np.float64],
-                       [random.random(), np.float64],
-                       [1+1j, np.complex128]]
-        self.iters = [[(0, 0, 1), np.float64],
-                      [(0, -5.1, np.pi), np.float64],
-                      [[70, 1e15, 2*np.pi], np.float64],
-                      [[5, random.random(), np.pi], np.float64],
-                      [np.array([4, -1, 3.7]), np.float64],
-                      [np.array([2.1, 0.0, -5*random.random()]), np.float64],
-                      [(1+1j, 1+1j, 1+1j), np.complex128],
-                      [(0, 0, 1j), np.complex128],
-                      [np.random.random(3) + np.random.random(3) * 1j,
-                       np.complex128]]
+        # dtype is computed automatically for array_like
+        self.consts = [[0, None],
+                       [-5., None],
+                       [np.pi, None],
+                       [1e-15, None],
+                       [1.2e12, None],
+                       [random.random(), None],
+                       [1+1j, None]]
+        self.iters = [[(0, 0, 1), None],
+                      [(0, -5.1, np.pi), None],
+                      [[70, 1e15, 2*np.pi], None],
+                      [[5, random.random(), np.pi], None],
+                      [np.array([4, -1, 3.7]), None],
+                      [np.array([2.1, 0.0, -5*random.random()]), None],
+                      [(1+1j, 1+1j, 1+1j), None],
+                      [(0, 0, 1j), None],
+                      [np.random.random(3) + np.random.random(3) * 1j, None]]
+        # dtype has to be specified for callable
         self.sfuncs = [[lambda c: 1, np.float64],
                        [lambda c: -2.4, np.float64],
                        [lambda c: -6.4e-15, np.float64],
@@ -286,6 +287,7 @@ class TestField:
         field = df.Field(mesh, dim=3, value={'default': (1, 1, 1)})
         assert np.all(field.array == (1, 1, 1))
 
+        # dtype has to be specified for isinstance(value, dict)
         field = df.Field(mesh, dim=3, value={'r1': (0, 0, 1+2j),
                                              'default': (1, 1, 1)},
                          dtype=np.complex128)
@@ -2177,7 +2179,7 @@ class TestField:
         assert df.Field(mesh, dim=3).allclose(np.mod(self.pf.phase, np.pi))
 
         # complex field
-        field = df.Field(mesh, dim=1, value=1 + 1j, dtype=np.complex128)
+        field = df.Field(mesh, dim=1, value=1 + 1j)
         real_field = field.real
         check_field(real_field)
         assert df.Field(mesh, dim=1, value=1).allclose(real_field)

--- a/discretisedfield/tools/tools.py
+++ b/discretisedfield/tools/tools.py
@@ -527,7 +527,7 @@ def max_neigbouring_cell_angle(field, /, units='rad'):
     y_angles = neigbouring_cell_angle(field, 'y', units=units).array.squeeze()
     z_angles = neigbouring_cell_angle(field, 'z', units=units).array.squeeze()
 
-    max_angles = np.zeros((*field.array.shape[:-1], 6), dtype=np.float64)
+    max_angles = np.zeros((*field.array.shape[:-1], 6))
     max_angles[1:, :, :, 0] = x_angles
     max_angles[:-1, :, :, 1] = x_angles
     max_angles[:, 1:, :, 2] = y_angles

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -30,11 +30,15 @@ def _(val, mesh, dim, dtype):
     if isinstance(val, numbers.Complex) and dim > 1 and val != 0:
         raise ValueError('Wrong dimension 1 provided for value;'
                          f' expected dimension is {dim}')
+    if dtype is None:
+        dtype = np.array(val).dtype
     return np.full((*mesh.n, dim), val, dtype=dtype)
 
 
 @as_array.register(collections.abc.Callable)
 def _(val, mesh, dim, dtype):
+    # will only be called on user input
+    # dtype must be specified by the user for complex values
     array = np.empty((*mesh.n, dim), dtype=dtype)
     for index, point in zip(mesh.indices, mesh):
         res = val(point)
@@ -44,6 +48,8 @@ def _(val, mesh, dim, dtype):
 
 @as_array.register(dict)
 def _(val, mesh, dim, dtype):
+    # will only be called on user input
+    # dtype must be specified by the user for complex values
     if 'default' in val and not callable(val['default']):
         fill_value = val['default']
     else:


### PR DESCRIPTION
Simplifies array creation and mathematical operations with fields.

Determining the array for `callable` or `dict` for `value` is more complex and therefore not done automatically. Instead, the numpy default (np.float64) is used by default. Furthermore, these types of value only occur during creation by the user where a different dtype can be easily specified (so we don't have any issues with wrong data types during operations on fields).