### PR TITLE
Improve performance

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -2415,10 +2415,16 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
         """
         plane_mesh = self.mesh.plane(*args, n=n, **kwargs)
-        return self.__class__(plane_mesh, dim=self.dim, value=self,
-                              components=self.components,
-                              dtype=self.array.dtype  # callable requires dtype
-                              )
+        axis_idx = plane_mesh.attributes['planeaxis']
+        plane_idx = self.mesh.point2index(plane_mesh.region.centre)[axis_idx]
+        slices = tuple(
+            slice(plane_idx, plane_idx + 1) if i == axis_idx
+            else slice(0, axis_len)
+            for i, axis_len in enumerate(self.array.shape)
+        )
+        return self.__class__(plane_mesh, dim=self.dim,
+                              value=self.array[slices],
+                              components=self.components)
 
     def __getitem__(self, item):
         """Extracts the field on a subregion.


### PR DESCRIPTION
Collects a number of performance improvements.

Tests are done for a vector field with 200 x 200 x 10 cells.

# cutting plane
`plane('x')`
- old: 125 ms
- new: 248 μs

`plane('z')`
- old: 2.55s
- new: 1.26ms

# plotting

`plane('z').scalar()`
- old: 5.4 s  (no timeit)
- new: 2.85 s  (no timeit)
- new + new plane implementation: 34 ms

`plane('z').scalar(filter_field=field.norm)`
- old: 7.16s  (no timeit)
- new: 5.95s  (no timeit)
- new + new plane implementation: 47 ms