### PR TITLE
Correct aspect ratio for mesh and region mpl calls.

### DIFF
--- a/discretisedfield/mesh.py
+++ b/discretisedfield/mesh.py
@@ -1207,7 +1207,7 @@ class Mesh:
         return df.Field(self, dim=3, value=dn, norm=norm)
 
     def mpl(self, *, ax=None, figsize=None, color=dfu.cp_hex[:2],
-            multiplier=None, filename=None, **kwargs):
+            multiplier=None, box_aspect='auto', filename=None, **kwargs):
         """``matplotlib`` plot.
 
         If ``ax`` is not passed, ``matplotlib.axes.Axes`` object is created
@@ -1282,15 +1282,17 @@ class Mesh:
 
         cell_region = df.Region(p1=self.region.pmin,
                                 p2=np.add(self.region.pmin, self.cell))
-        self.region.mpl(ax=ax, color=color[0], multiplier=multiplier, **kwargs)
-        cell_region.mpl(ax=ax, color=color[1], multiplier=multiplier, **kwargs)
+        self.region.mpl(ax=ax, color=color[0], multiplier=multiplier,
+                        box_aspect=box_aspect, **kwargs)
+        cell_region.mpl(ax=ax, color=color[1], multiplier=multiplier,
+                        box_aspect=None, **kwargs)
 
         if filename is not None:
             plt.savefig(filename, bbox_inches='tight', pad_inches=0)
 
     def mpl_subregions(self, *, ax=None, figsize=None, color=dfu.cp_hex,
                        multiplier=None, filename=None, show_region=False,
-                       **kwargs):
+                       box_aspect='auto', **kwargs):
         """``matplotlib`` subregions plot.
 
         If ``ax`` is not passed, ``matplotlib.axes.Axes`` object is created
@@ -1362,15 +1364,22 @@ class Mesh:
             fig = plt.figure(figsize=figsize)
             ax = fig.add_subplot(111, projection='3d')
 
+        if box_aspect == 'auto':
+            ax.set_box_aspect(self.region.edges)
+        elif box_aspect is not None:
+            ax.set_box_aspect(box_aspect)
+
         if multiplier is None:
             multiplier = uu.si_max_multiplier(self.region.edges)
 
         if show_region:
-            self.region.mpl(ax=ax, multiplier=multiplier, color='grey')
+            self.region.mpl(ax=ax, multiplier=multiplier, color='grey',
+                            box_aspect=None)
 
         for i, subregion in enumerate(self.subregions.values()):
             subregion.mpl(ax=ax, multiplier=multiplier,
-                          color=color[i % len(color)], **kwargs)
+                          color=color[i % len(color)], box_aspect=None,
+                          **kwargs)
 
         if filename is not None:
             plt.savefig(filename, bbox_inches='tight', pad_inches=0)

--- a/discretisedfield/mesh.py
+++ b/discretisedfield/mesh.py
@@ -1253,6 +1253,13 @@ class Mesh:
 
             Axes multiplier. Defaults to ``None``.
 
+        box_aspect : str, array_like (3), optional
+
+            Set the aspect-ratio of the plot. If set to `auto` the aspect ratio
+            is determined from the edge lengths of the region on which the mesh
+            is defined. To set different aspect ratios a tuple can be passed.
+            Defaults to ``'auto'``.
+
         filename : str, optional
 
             If filename is passed, the plot is saved. Defaults to ``None``.
@@ -1291,8 +1298,8 @@ class Mesh:
             plt.savefig(filename, bbox_inches='tight', pad_inches=0)
 
     def mpl_subregions(self, *, ax=None, figsize=None, color=dfu.cp_hex,
-                       multiplier=None, filename=None, show_region=False,
-                       box_aspect='auto', **kwargs):
+                       multiplier=None, show_region=False, box_aspect='auto',
+                       filename=None, **kwargs):
         """``matplotlib`` subregions plot.
 
         If ``ax`` is not passed, ``matplotlib.axes.Axes`` object is created
@@ -1336,13 +1343,20 @@ class Mesh:
 
             Axes multiplier. Defaults to ``None``.
 
-        filename : str, optional
-
-            If filename is passed, the plot is saved. Defaults to ``None``.
-
         show_region : bool, optional
 
             If ``True`` also plot the whole region. Defaults to ``False``.
+
+        box_aspect : str, array_like (3), optional
+
+            Set the aspect-ratio of the plot. If set to `auto` the aspect ratio
+            is determined from the edge lengths of the region on which the mesh
+            is defined. To set different aspect ratios a tuple can be passed.
+            Defaults to ``'auto'``.
+
+        filename : str, optional
+
+            If filename is passed, the plot is saved. Defaults to ``None``.
 
         Examples
         --------

--- a/discretisedfield/mesh.py
+++ b/discretisedfield/mesh.py
@@ -1255,10 +1255,10 @@ class Mesh:
 
         box_aspect : str, array_like (3), optional
 
-            Set the aspect-ratio of the plot. If set to `auto` the aspect ratio
-            is determined from the edge lengths of the region on which the mesh
-            is defined. To set different aspect ratios a tuple can be passed.
-            Defaults to ``'auto'``.
+            Set the aspect-ratio of the plot. If set to `'auto'` the aspect
+            ratio is determined from the edge lengths of the region on which
+            the mesh is defined. To set different aspect ratios a tuple can be
+            passed. Defaults to ``'auto'``.
 
         filename : str, optional
 
@@ -1349,10 +1349,10 @@ class Mesh:
 
         box_aspect : str, array_like (3), optional
 
-            Set the aspect-ratio of the plot. If set to `auto` the aspect ratio
-            is determined from the edge lengths of the region on which the mesh
-            is defined. To set different aspect ratios a tuple can be passed.
-            Defaults to ``'auto'``.
+            Set the aspect-ratio of the plot. If set to `'auto'` the aspect
+            ratio is determined from the edge lengths of the region on which
+            the mesh is defined. To set different aspect ratios a tuple can be
+            passed. Defaults to ``'auto'``.
 
         filename : str, optional
 

--- a/discretisedfield/plotting/mpl_region.py
+++ b/discretisedfield/plotting/mpl_region.py
@@ -61,9 +61,10 @@ class MplRegion(Mpl):
 
         box_aspect : str, array_like (3), optional
 
-            Set the aspect-ratio of the plot. If set to `auto` the aspect ratio
-            is determined from the edge lengths of the region. To set different
-            aspect ratios a tuple can be passed. Defaults to ``'auto'``.
+            Set the aspect-ratio of the plot. If set to `'auto'` the aspect
+            ratio is determined from the edge lengths of the region. To set
+            different aspect ratios a tuple can be passed. Defaults to
+            ``'auto'``.
 
         filename : str, optional
 

--- a/discretisedfield/plotting/mpl_region.py
+++ b/discretisedfield/plotting/mpl_region.py
@@ -13,9 +13,8 @@ class MplRegion(Mpl):
                  figsize=None,
                  multiplier=None,
                  color=dfu.cp_hex[0],
-                 filename=None,
                  box_aspect='auto',
-                 mode='wireframe',
+                 filename=None,
                  **kwargs):
         r"""``matplotlib`` plot.
 
@@ -59,6 +58,12 @@ class MplRegion(Mpl):
         multiplier : numbers.Real, optional
 
             Axes multiplier. Defaults to ``None``.
+
+        box_aspect : str, array_like (3), optional
+
+            Set the aspect-ratio of the plot. If set to `auto` the aspect ratio
+            is determined from the edge lengths of the region. To set different
+            aspect ratios a tuple can be passed. Defaults to ``'auto'``.
 
         filename : str, optional
 

--- a/discretisedfield/plotting/mpl_region.py
+++ b/discretisedfield/plotting/mpl_region.py
@@ -14,6 +14,8 @@ class MplRegion(Mpl):
                  multiplier=None,
                  color=dfu.cp_hex[0],
                  filename=None,
+                 box_aspect='auto',
+                 mode='wireframe',
                  **kwargs):
         r"""``matplotlib`` plot.
 
@@ -81,6 +83,11 @@ class MplRegion(Mpl):
         kwargs.setdefault('color', color)
 
         rescaled_region = self.region / multiplier
+
+        if box_aspect == 'auto':
+            ax.set_box_aspect(rescaled_region.edges)
+        elif box_aspect is not None:
+            ax.set_box_aspect(box_aspect)
 
         dfu.plot_box(ax=ax,
                      pmin=rescaled_region.pmin,

--- a/discretisedfield/tests/test_mesh.py
+++ b/discretisedfield/tests/test_mesh.py
@@ -781,6 +781,7 @@ class TestMesh:
         for p1, p2, n, cell in self.valid_args:
             mesh = df.Mesh(region=df.Region(p1=p1, p2=p2), n=n, cell=cell)
             mesh.mpl()
+            mesh.mpl(box_aspect=[1, 2, 3])
 
             filename = 'figure.pdf'
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -810,7 +811,7 @@ class TestMesh:
         mesh = df.Mesh(p1=p1, p2=p2, cell=cell, subregions=subregions)
 
         # matplotlib tests
-        mesh.mpl_subregions()
+        mesh.mpl_subregions(box_aspect=(1, 1, 1), show_region=True)
 
         filename = 'figure.pdf'
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/discretisedfield/tests/test_region.py
+++ b/discretisedfield/tests/test_region.py
@@ -293,7 +293,7 @@ class TestRegion:
         # Check if it runs.
         region.mpl()
         region.mpl(figsize=(10, 10), multiplier=1e-9, color=dfu.cp_hex[1],
-                   linewidth=3, linestyle='dashed')
+                   linewidth=3, box_aspect=(1, 1.5, 2), linestyle='dashed')
 
         filename = 'figure.pdf'
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
There is a problem with overlapping ticks and axis labels. However, the benefit
of quickly seeing the shape from the plot (without reading axis ticks) should
outweight this issue. If required, one can always manually set better
ticks/labels after creating the plot.

Old behavior (can be obtained by explicitly passing the new parameter `box_aspect`, `(4, 4, 3)` is the `matplotlib` default):
![grafik](https://user-images.githubusercontent.com/67915889/159687052-d7c6fdf3-92b1-41ec-a6f0-df6f2bb14aac.png)

New behaviour (obtained with `box_aspect='auto'`, which is the default):
![grafik](https://user-images.githubusercontent.com/67915889/159687166-fdff3c4c-6662-401c-8858-727b017a315e.png)
