### PR TITLE
New initialisation method when passin a `df.Field` using the new xarray functionality.

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -263,8 +263,8 @@ class Field:
         .. seealso:: :py:func:`~discretisedfield.Field.array`
 
         """
-        value_array = as_array(self._value, self.mesh, self.dim,
-                               dtype=self.dtype)
+        value_array = _as_array(self._value, self.mesh, self.dim,
+                                dtype=self.dtype)
         if np.array_equal(self.array, value_array):
             return self._value
         else:
@@ -273,7 +273,7 @@ class Field:
     @value.setter
     def value(self, val):
         self._value = val
-        self.array = as_array(val, self.mesh, self.dim, dtype=self.dtype)
+        self.array = _as_array(val, self.mesh, self.dim, dtype=self.dtype)
 
     @property
     def components(self):
@@ -362,7 +362,7 @@ class Field:
 
     @array.setter
     def array(self, val):
-        self._array = as_array(val, self.mesh, self.dim, dtype=self.dtype)
+        self._array = _as_array(val, self.mesh, self.dim, dtype=self.dtype)
 
     @property
     def norm(self):
@@ -450,7 +450,7 @@ class Field:
                 raise ValueError(msg)
 
             self.array /= self.norm.array  # normalise to 1
-            self.array *= as_array(val, self.mesh, dim=1, dtype=None)
+            self.array *= _as_array(val, self.mesh, dim=1, dtype=None)
 
     def __abs__(self):
         """Field norm.
@@ -3798,18 +3798,18 @@ class Field:
 
 
 @functools.singledispatch
-def as_array(val, mesh, dim, dtype):
+def _as_array(val, mesh, dim, dtype):
     raise TypeError('Unsupported type {type(val)}.')
 
 
 # to avoid str being interpreted as iterable
-@as_array.register(str)
+@_as_array.register(str)
 def _(val, mesh, dim, dtype):
     raise TypeError('Unsupported type {type(val)}.')
 
 
-@as_array.register(numbers.Complex)
-@as_array.register(collections.abc.Iterable)
+@_as_array.register(numbers.Complex)
+@_as_array.register(collections.abc.Iterable)
 def _(val, mesh, dim, dtype):
     if isinstance(val, numbers.Complex) and dim > 1 and val != 0:
         raise ValueError('Wrong dimension 1 provided for value;'
@@ -3819,7 +3819,7 @@ def _(val, mesh, dim, dtype):
     return np.full((*mesh.n, dim), val, dtype=dtype)
 
 
-@as_array.register(collections.abc.Callable)
+@_as_array.register(collections.abc.Callable)
 def _(val, mesh, dim, dtype):
     # will only be called on user input
     # dtype must be specified by the user for complex values
@@ -3830,7 +3830,7 @@ def _(val, mesh, dim, dtype):
     return array
 
 
-@as_array.register(dict)
+@_as_array.register(dict)
 def _(val, mesh, dim, dtype):
     # will only be called on user input
     # dtype must be specified by the user for complex values
@@ -3851,7 +3851,7 @@ def _(val, mesh, dim, dtype):
             continue
         else:
             slices = mesh.region2slices(submesh.region)
-            array[slices] = as_array(subval, submesh, dim, dtype)
+            array[slices] = _as_array(subval, submesh, dim, dtype)
 
     if np.any(np.isnan(array)):
         # not all subregion keys specified and 'default' is missing or callable

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import math
 import numbers
 import struct
@@ -24,7 +25,7 @@ from .mesh import Mesh
 
 @ts.typesystem(mesh=ts.Typed(expected_type=Mesh, const=True),
                dim=ts.Scalar(expected_type=int, positive=True, const=True))
-class Field(collections.abc.Callable):  # could be avoided by using type hints
+class Field:
     """Finite-difference field.
 
     This class specifies a finite-difference field and defines operations for
@@ -262,8 +263,8 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
         .. seealso:: :py:func:`~discretisedfield.Field.array`
 
         """
-        value_array = dfu.as_array(self._value, self.mesh, self.dim,
-                                   dtype=self.dtype)
+        value_array = as_array(self._value, self.mesh, self.dim,
+                               dtype=self.dtype)
         if np.array_equal(self.array, value_array):
             return self._value
         else:
@@ -272,7 +273,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
     @value.setter
     def value(self, val):
         self._value = val
-        self.array = dfu.as_array(val, self.mesh, self.dim, dtype=self.dtype)
+        self.array = as_array(val, self.mesh, self.dim, dtype=self.dtype)
 
     @property
     def components(self):
@@ -361,7 +362,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
 
     @array.setter
     def array(self, val):
-        self._array = dfu.as_array(val, self.mesh, self.dim, dtype=self.dtype)
+        self._array = as_array(val, self.mesh, self.dim, dtype=self.dtype)
 
     @property
     def norm(self):
@@ -449,7 +450,7 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                 raise ValueError(msg)
 
             self.array /= self.norm.array  # normalise to 1
-            self.array *= dfu.as_array(val, self.mesh, dim=1, dtype=None)
+            self.array *= as_array(val, self.mesh, dim=1, dtype=None)
 
     def __abs__(self):
         """Field norm.
@@ -3794,3 +3795,72 @@ class Field(collections.abc.Callable):  # could be avoided by using type hints
                    value=val,
                    components=comp,
                    dtype=xa.values.dtype)
+
+
+@functools.singledispatch
+def as_array(val, mesh, dim, dtype):
+    raise TypeError('Unsupported type {type(val)}.')
+
+
+# to avoid str being interpreted as iterable
+@as_array.register(str)
+def _(val, mesh, dim, dtype):
+    raise TypeError('Unsupported type {type(val)}.')
+
+
+@as_array.register(numbers.Complex)
+@as_array.register(collections.abc.Iterable)
+def _(val, mesh, dim, dtype):
+    if isinstance(val, numbers.Complex) and dim > 1 and val != 0:
+        raise ValueError('Wrong dimension 1 provided for value;'
+                         f' expected dimension is {dim}')
+    if dtype is None:
+        dtype = max(np.asarray(val).dtype, np.float64)
+    return np.full((*mesh.n, dim), val, dtype=dtype)
+
+
+@as_array.register(collections.abc.Callable)
+def _(val, mesh, dim, dtype):
+    # will only be called on user input
+    # dtype must be specified by the user for complex values
+    array = np.empty((*mesh.n, dim), dtype=dtype)
+    for index, point in zip(mesh.indices, mesh):
+        res = val(point)
+        array[index] = res
+    return array
+
+
+@as_array.register(dict)
+def _(val, mesh, dim, dtype):
+    # will only be called on user input
+    # dtype must be specified by the user for complex values
+    if dtype is None:
+        dtype = np.float64
+    if 'default' in val and not callable(val['default']):
+        fill_value = val['default']
+    else:
+        fill_value = np.nan
+    array = np.full((*mesh.n, dim), fill_value, dtype=dtype)
+
+    for subregion in reversed(mesh.subregions.keys()):
+        # subregions can overlap, first subregion takes precedence
+        try:
+            submesh = mesh[subregion]
+            subval = val[subregion]
+        except KeyError:
+            continue
+        else:
+            slices = mesh.region2slices(submesh.region)
+            array[slices] = as_array(subval, submesh, dim, dtype)
+
+    if np.any(np.isnan(array)):
+        # not all subregion keys specified and 'default' is missing or callable
+        if 'default' not in val:
+            raise KeyError("Key 'default' required if not all subregion keys"
+                           " are specified.")
+        subval = val['default']
+        for ix, iy, iz in np.argwhere(np.isnan(array[..., 0])):
+            # only spatial indices required -> array[..., 0]
+            array[ix, iy, iz] = subval(mesh.index2point((ix, iy, iz)))
+
+    return array

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3832,12 +3832,18 @@ def _(val, mesh, dim, dtype):
 
 @_as_array.register(Field)
 def _(val, mesh, dim, dtype):
-    # reshaping required for scalar fields
-    # where the xarray is only 3 dimensional
-    return val.to_xarray().sel(x=mesh.midpoints.x,
-                               y=mesh.midpoints.y,
-                               z=mesh.midpoints.z,
-                               method='nearest').data.reshape(mesh.n + (-1,))
+    if mesh.region not in val.mesh.region:
+        raise ValueError(f'The region {val.mesh.region} of the provided field'
+                         f' does not contain the region {mesh.region} of the'
+                         ' field that is being created.')
+    value = val.to_xarray().sel(x=mesh.midpoints.x,
+                                y=mesh.midpoints.y,
+                                z=mesh.midpoints.z,
+                                method='nearest').data
+    if dim == 1:
+        # xarray dataarrays for scalar data are three dimensional
+        return value.reshape(mesh.n + (-1,))
+    return value
 
 
 @_as_array.register(dict)

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3814,8 +3814,7 @@ def _(val, mesh, dim, dtype):
     if isinstance(val, numbers.Complex) and dim > 1 and val != 0:
         raise ValueError('Wrong dimension 1 provided for value;'
                          f' expected dimension is {dim}')
-    if dtype is None:
-        dtype = max(np.asarray(val).dtype, np.float64)
+    dtype = dtype or max(np.asarray(val).dtype, np.float64)
     return np.full((*mesh.n, dim), val, dtype=dtype)
 
 
@@ -3825,8 +3824,7 @@ def _(val, mesh, dim, dtype):
     # dtype must be specified by the user for complex values
     array = np.empty((*mesh.n, dim), dtype=dtype)
     for index, point in zip(mesh.indices, mesh):
-        res = val(point)
-        array[index] = res
+        array[index] = val(point)
     return array
 
 
@@ -3850,12 +3848,9 @@ def _(val, mesh, dim, dtype):
 def _(val, mesh, dim, dtype):
     # will only be called on user input
     # dtype must be specified by the user for complex values
-    if dtype is None:
-        dtype = np.float64
-    if 'default' in val and not callable(val['default']):
-        fill_value = val['default']
-    else:
-        fill_value = np.nan
+    dtype = dtype or np.float64
+    fill_value = val['default'] if 'default' in val and not callable(
+        val['default']) else np.nan
     array = np.full((*mesh.n, dim), fill_value, dtype=dtype)
 
     for subregion in reversed(mesh.subregions.keys()):

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3832,10 +3832,12 @@ def _(val, mesh, dim, dtype):
 
 @_as_array.register(Field)
 def _(val, mesh, dim, dtype):
+    # reshaping required for scalar fields
+    # where the xarray is only 3 dimensional
     return val.to_xarray().sel(x=mesh.midpoints.x,
                                y=mesh.midpoints.y,
                                z=mesh.midpoints.z,
-                               method='nearest').data
+                               method='nearest').data.reshape(mesh.n + (-1,))
 
 
 @_as_array.register(dict)

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3831,9 +3831,9 @@ def _(val, mesh, dim, dtype):
 @_as_array.register(Field)
 def _(val, mesh, dim, dtype):
     if mesh.region not in val.mesh.region:
-        raise ValueError(f'The region {val.mesh.region} of the provided field'
-                         f' does not contain the region {mesh.region} of the'
-                         ' field that is being created.')
+        raise ValueError(f'{val.mesh.region} of the provided field does not '
+                         f'contain {mesh.region} of the field that is being '
+                         'created.')
     value = val.to_xarray().sel(x=mesh.midpoints.x,
                                 y=mesh.midpoints.y,
                                 z=mesh.midpoints.z,

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3830,6 +3830,14 @@ def _(val, mesh, dim, dtype):
     return array
 
 
+@_as_array.register(Field)
+def _(val, mesh, dim, dtype):
+    return val.to_xarray().sel(x=mesh.midpoints.x,
+                               y=mesh.midpoints.y,
+                               z=mesh.midpoints.z,
+                               method='nearest').data
+
+
 @_as_array.register(dict)
 def _(val, mesh, dim, dtype):
     # will only be called on user input

--- a/discretisedfield/ovf2vtk.py
+++ b/discretisedfield/ovf2vtk.py
@@ -14,28 +14,23 @@ def ovf2vtk():
         prog='ovf2vtk',
         description='ovf2vtk - OVF to VTK file format conversion.'
     )
-    parser.add_argument('--input', '-i', type=argparse.FileType('r'),
-                        nargs='+', required=True, help='Input OVF file(s).')
-    parser.add_argument('--output', '-o', type=argparse.FileType('w'),
-                        nargs='+', required=False, help='Output VTK file(s).')
+    parser.add_argument('--input', '-i', nargs='+', required=True,
+                        help='Input OVF file(s).')
+    parser.add_argument('--output', '-o', nargs='+', required=False,
+                        help='Output VTK file(s).')
     args = parser.parse_args()
 
-    input_files = [f.name for f in args.input]
-
     if args.output:
-        # Output filenames provided.
-        if len(args.input) == len(args.output):
-            output_files = [f.name for f in args.output]
-        else:
+        if len(args.input) != len(args.output):
             msg = (f'The number of input files ({len(args.input)}) does not '
                    f'match the number of output files ({len(args.output)}).')
             raise ValueError(msg)
     else:
         # Output filenames are not provided and they are generated
         # automatically.
-        output_files = [f'{filename[:-4]}.vtk' for filename in input_files]
+        args.output = [f'{filename[:-4]}.vtk' for filename in args.input]
 
-    for input_file, output_file in zip(input_files, output_files):
+    for input_file, output_file in zip(args.input, args.output):
         field = df.Field.fromfile(input_file)
         field.write(output_file)
 

--- a/discretisedfield/region.py
+++ b/discretisedfield/region.py
@@ -407,8 +407,12 @@ class Region:
 
         """
         if isinstance(other, collections.abc.Iterable):
-            return not np.any(np.less(other, self.pmin) |
-                              np.greater(other, self.pmax))
+            return np.all(np.logical_and(
+                np.less_equal(self.pmin, other) | np.allclose(self.pmin,
+                                                              other, atol=0),
+                np.greater_equal(self.pmax, other) | np.allclose(self.pmax,
+                                                                 other, atol=0)
+            ))
         if isinstance(other, self.__class__):
             return other.pmin in self and other.pmax in self
 

--- a/discretisedfield/region.py
+++ b/discretisedfield/region.py
@@ -79,7 +79,6 @@ class Region:
         self.p1 = tuple(p1)
         self.p2 = tuple(p2)
         self.unit = unit
-
         self.tolerance_factor = tolerance_factor
 
         if not np.all(self.edges):

--- a/discretisedfield/tests/test_region.py
+++ b/discretisedfield/tests/test_region.py
@@ -165,21 +165,61 @@ class TestRegion:
         assert region1 != region3
         assert not region1 == region3
 
+    def test_tolerance_factor(self):
+        p1 = (0, 0, 0)
+        p2 = (100e-9, 100e-9, 100e-9)
+        region = df.Region(p1=p1, p2=p2)
+        assert np.isclose(region.tolerance_factor, 1e-12)
+
+        region = df.Region(p1=p1, p2=p2, tolerance_factor=1e-3)
+        assert np.isclose(region.tolerance_factor, 1e-3)
+        region.tolerance_factor = 1e-6
+        assert np.isclose(region.tolerance_factor, 1e-6)
+
     def test_contains(self):
         p1 = (0, 10e-9, 0)
         p2 = (10e-9, 0, 20e-9)
         region = df.Region(p1=p1, p2=p2)
 
         check_region(region)
-        tol = 1e-18
+        tol = np.min(region.edges) * region.tolerance_factor
+        tol_in = tol / 2
+        tol_out = tol * 2
         assert (0, 0, 0) in region
-        assert (0-tol, 0, 0) not in region
-        assert (0, 0-tol, 0) not in region
-        assert (0, 0, 0-tol) not in region
+        assert (-tol_in, 0, 0) in region
+        assert (0, -tol_in, 0) in region
+        assert (0, 0, -tol_in) in region
         assert (10e-9, 10e-9, 20e-9) in region
-        assert (10e-9+tol, 10e-9, 20e-9) not in region
-        assert (10e-9, 10e-9+tol, 20e-9) not in region
-        assert (10e-9, 10e-9, 20e-9+tol) not in region
+        assert (10e-9 + tol_in, 10e-9, 20e-9) in region
+        assert (10e-9, 10e-9 + tol_in, 20e-9) in region
+        assert (10e-9, 10e-9, 20e-9 + tol_in) in region
+
+        assert (-tol_out, 0, 0) not in region
+        assert (0, -tol_out, 0) not in region
+        assert (0, 0, -tol_out) not in region
+        assert (10e-9 + tol_out, 10e-9, 20e-9) not in region
+        assert (10e-9, 10e-9 + tol_out, 20e-9) not in region
+        assert (10e-9, 10e-9, 20e-9 + tol_out) not in region
+
+        region.tolerance_factor = 1.
+        tol = np.min(region.edges) * region.tolerance_factor
+        tol_in = tol / 2
+        tol_out = tol * 2
+        assert (0, 0, 0) in region
+        assert (-tol_in, 0, 0) in region
+        assert (0, -tol_in, 0) in region
+        assert (0, 0, -tol_in) in region
+        assert (10e-9, 10e-9, 20e-9) in region
+        assert (10e-9 + tol_in, 10e-9, 20e-9) in region
+        assert (10e-9, 10e-9 + tol_in, 20e-9) in region
+        assert (10e-9, 10e-9, 20e-9 + tol_in) in region
+
+        assert (-tol_out, 0, 0) not in region
+        assert (0, -tol_out, 0) not in region
+        assert (0, 0, -tol_out) not in region
+        assert (10e-9 + tol_out, 10e-9, 20e-9) not in region
+        assert (10e-9, 10e-9 + tol_out, 20e-9) not in region
+        assert (10e-9, 10e-9, 20e-9 + tol_out) not in region
 
     def test_or(self):
         # x-direction

--- a/discretisedfield/util/__init__.py
+++ b/discretisedfield/util/__init__.py
@@ -1,3 +1,3 @@
-from .util import (array2tuple, as_array, assemble_index, axesdict,
-                   bergluescher_angle, cp_hex, cp_int, fromvtk_legacy, hls2rgb,
-                   normalise_to_range, plot_box, plot_line, raxesdict)
+from .util import (array2tuple, assemble_index, axesdict, bergluescher_angle,
+                   cp_hex, cp_int, fromvtk_legacy, hls2rgb, normalise_to_range,
+                   plot_box, plot_line, raxesdict)

--- a/discretisedfield/util/util.py
+++ b/discretisedfield/util/util.py
@@ -1,8 +1,6 @@
 import cmath
 import collections
 import colorsys
-import functools
-import numbers
 
 import numpy as np
 
@@ -19,75 +17,6 @@ cp_int = [int(color[1:], 16) for color in cp_hex]
 
 def array2tuple(array):
     return array.item() if array.size == 1 else tuple(array.tolist())
-
-
-@functools.singledispatch
-def as_array(val, mesh, dim, dtype):
-    raise TypeError('Unsupported type {type(val)}.')
-
-
-# to avoid str being interpreted as iterable
-@as_array.register(str)
-def _(val, mesh, dim, dtype):
-    raise TypeError('Unsupported type {type(val)}.')
-
-
-@as_array.register(numbers.Complex)
-@as_array.register(collections.abc.Iterable)
-def _(val, mesh, dim, dtype):
-    if isinstance(val, numbers.Complex) and dim > 1 and val != 0:
-        raise ValueError('Wrong dimension 1 provided for value;'
-                         f' expected dimension is {dim}')
-    if dtype is None:
-        dtype = max(np.asarray(val).dtype, np.float64)
-    return np.full((*mesh.n, dim), val, dtype=dtype)
-
-
-@as_array.register(collections.abc.Callable)
-def _(val, mesh, dim, dtype):
-    # will only be called on user input
-    # dtype must be specified by the user for complex values
-    array = np.empty((*mesh.n, dim), dtype=dtype)
-    for index, point in zip(mesh.indices, mesh):
-        res = val(point)
-        array[index] = res
-    return array
-
-
-@as_array.register(dict)
-def _(val, mesh, dim, dtype):
-    # will only be called on user input
-    # dtype must be specified by the user for complex values
-    if dtype is None:
-        dtype = np.float64
-    if 'default' in val and not callable(val['default']):
-        fill_value = val['default']
-    else:
-        fill_value = np.nan
-    array = np.full((*mesh.n, dim), fill_value, dtype=dtype)
-
-    for subregion in reversed(mesh.subregions.keys()):
-        # subregions can overlap, first subregion takes precedence
-        try:
-            submesh = mesh[subregion]
-            subval = val[subregion]
-        except KeyError:
-            continue
-        else:
-            slices = mesh.region2slices(submesh.region)
-            array[slices] = as_array(subval, submesh, dim, dtype)
-
-    if np.any(np.isnan(array)):
-        # not all subregion keys specified and 'default' is missing or callable
-        if 'default' not in val:
-            raise KeyError("Key 'default' required if not all subregion keys"
-                           " are specified.")
-        subval = val['default']
-        for ix, iy, iz in np.argwhere(np.isnan(array[..., 0])):
-            # only spatial indices required -> array[..., 0]
-            array[ix, iy, iz] = subval(mesh.index2point((ix, iy, iz)))
-
-    return array
 
 
 def bergluescher_angle(v1, v2, v3):


### PR DESCRIPTION
Test
- field with `mesh.n = (100, 100, 10)`
- creation of a new field with `mesh.n = (10, 10, 10)` and passing the old field to `value`

Performance improvement:
- old implementation (using that the field is callable): ~ 6.5 s
- new implementation (interpolation done by `xarray`): ~ 5 ms

@swapneelap This is probably the first use case for your new method.