### PR TITLE
Fix region contains

### DIFF
--- a/discretisedfield/region.py
+++ b/discretisedfield/region.py
@@ -429,9 +429,9 @@ class Region:
             return np.all(
                 np.logical_and(
                     np.less_equal(self.pmin, other)
-                    | np.allclose(self.pmin, other, rtol=tol, atol=tol),
+                    | np.isclose(self.pmin, other, rtol=tol, atol=tol),
                     np.greater_equal(self.pmax, other)
-                    | np.allclose(self.pmax, other, rtol=tol, atol=tol),
+                    | np.isclose(self.pmax, other, rtol=tol, atol=tol),
                 )
             )
         if isinstance(other, self.__class__):

--- a/discretisedfield/tests/test_region.py
+++ b/discretisedfield/tests/test_region.py
@@ -215,9 +215,9 @@ class TestRegion:
         assert (-tol_in, 0, 0) in region
         assert (0, -tol_in, 0) in region
         assert (0, 0, -tol_in) in region
-        assert (10e-9, 10e-9, 20e-9) in region
-        assert (10e-9 + tol_in, 10e-9, 20e-9) in region
-        assert (10e-9, 10e-9 + tol_in, 20e-9) in region
+        assert (10e-9, 10e-9, 10e-9) in region
+        assert (10e-9 + tol_in, 10e-9, 10e-9) in region
+        assert (10e-9, 10e-9 + tol_in, 10e-9) in region
         assert (10e-9, 10e-9, 20e-9 + tol_in) in region
 
         assert (-tol_out, 0, 0) not in region

--- a/discretisedfield/tests/test_region.py
+++ b/discretisedfield/tests/test_region.py
@@ -196,9 +196,9 @@ class TestRegion:
         assert (0, -tol_in, 0) in region
         assert (0, 0, -tol_in) in region
         assert (10e-9, 10e-9, 20e-9) in region
-        assert (10e-9 + tol_in, 10e-9, 20e-9) in region
-        assert (10e-9, 10e-9 + tol_in, 20e-9) in region
-        assert (10e-9, 10e-9, 20e-9 + tol_in) in region
+        assert (10e-9 + tol_in, 10e-9, 10e-9) in region
+        assert (10e-9, 10e-9 + tol_in, 10e-9) in region
+        assert (1e-9, 3e-9, 20e-9 + tol_in) in region
 
         assert (-tol_out, 0, 0) not in region
         assert (0, -tol_out, 0) not in region
@@ -215,9 +215,9 @@ class TestRegion:
         assert (-tol_in, 0, 0) in region
         assert (0, -tol_in, 0) in region
         assert (0, 0, -tol_in) in region
-        assert (10e-9, 10e-9, 10e-9) in region
-        assert (10e-9 + tol_in, 10e-9, 10e-9) in region
-        assert (10e-9, 10e-9 + tol_in, 10e-9) in region
+        assert (10e-9, 10e-9, 20e-9) in region
+        assert (10e-9 + tol_in, 10e-9, 20e-9) in region
+        assert (10e-9, 10e-9 + tol_in, 20e-9) in region
         assert (10e-9, 10e-9, 20e-9 + tol_in) in region
 
         assert (-tol_out, 0, 0) not in region


### PR DESCRIPTION
The test `p in region` fails if some directions are inside the region and some within floating point accuracy outside the region.