### PR TITLE
Rename: field.units -> field.unit

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -63,7 +63,7 @@ class Field:
         callable and dict ``value`` the numpy default (currently
         ``float64``) is used. Defaults to ``None``.
 
-    units : str, optional
+    unit : str, optional
 
         Physical unit of the field.
 
@@ -132,7 +132,7 @@ class Field:
         norm=None,
         vdims=None,
         dtype=None,
-        units=None,
+        unit=None,
         **kwargs,
     ):
         if not isinstance(mesh, df.Mesh):
@@ -153,7 +153,7 @@ class Field:
 
         self.dtype = dtype
 
-        self.units = units
+        self.unit = unit
 
         self.value = value
         self.norm = norm
@@ -188,7 +188,7 @@ class Field:
         return self._nvdim
 
     @property
-    def units(self):
+    def unit(self):
         """Unit of the field.
 
         Returns
@@ -199,8 +199,8 @@ class Field:
         """
         return self._unit
 
-    @units.setter
-    def units(self, unit):
+    @unit.setter
+    def unit(self, unit):
         if unit is not None and not isinstance(unit, str):
             raise TypeError("'units' must be of type str.")
         self._unit = unit
@@ -499,7 +499,7 @@ class Field:
         """
         res = np.linalg.norm(self.array, axis=-1, keepdims=True)
 
-        return self.__class__(self.mesh, nvdim=1, value=res, units=self.units)
+        return self.__class__(self.mesh, nvdim=1, value=res, unit=self.unit)
 
     @norm.setter
     def norm(self, val):
@@ -543,7 +543,7 @@ class Field:
 
         """
         return self.__class__(
-            self.mesh, nvdim=self.nvdim, value=np.abs(self.array), units=self.units
+            self.mesh, nvdim=self.nvdim, value=np.abs(self.array), unit=self.unit
         )
 
     @property
@@ -581,7 +581,7 @@ class Field:
             nvdim=self.nvdim,
             value=0,
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     @property
@@ -856,7 +856,7 @@ class Field:
         if self.vdims is not None and attr in self.vdims:
             attr_array = self.array[..., self.vdims.index(attr), np.newaxis]
             return self.__class__(
-                mesh=self.mesh, nvdim=1, value=attr_array, units=self.units
+                mesh=self.mesh, nvdim=1, value=attr_array, unit=self.unit
             )
         else:
             msg = f"Object has no attribute {attr}."
@@ -1822,7 +1822,7 @@ class Field:
             nvdim=self.nvdim,
             value=padded_array,
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     def derivative(self, direction, n=1):
@@ -2537,7 +2537,7 @@ class Field:
             nvdim=self.nvdim,
             value=value,
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     def __getitem__(self, item):
@@ -2620,7 +2620,7 @@ class Field:
             nvdim=self.nvdim,
             value=self.array[tuple(slices)],
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     def project(self, direction):
@@ -3264,7 +3264,7 @@ class Field:
             nvdim=self.nvdim,
             value=self.array.real,
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     @property
@@ -3275,7 +3275,7 @@ class Field:
             nvdim=self.nvdim,
             value=self.array.imag,
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     @property
@@ -3306,7 +3306,7 @@ class Field:
             nvdim=self.nvdim,
             value=self.array.conjugate(),
             vdims=self.vdims,
-            units=self.units,
+            unit=self.unit,
         )
 
     # TODO check and write tests
@@ -3450,7 +3450,7 @@ class Field:
             coords=data_array_coords,
             name=name,
             attrs=dict(
-                units=units or self.units,
+                units=units or self.unit,
                 cell=self.mesh.cell,
                 pmin=self.mesh.region.pmin,
                 pmax=self.mesh.region.pmax,

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -202,7 +202,7 @@ class Field:
     @unit.setter
     def unit(self, unit):
         if unit is not None and not isinstance(unit, str):
-            raise TypeError("'units' must be of type str.")
+            raise TypeError("'unit' must be of type str.")
         self._unit = unit
 
     @property

--- a/discretisedfield/html/templates/field.jinja2
+++ b/discretisedfield/html/templates/field.jinja2
@@ -12,7 +12,7 @@
       </ul>
     </li>
   {% endif -%}
-  {% if field.units is not none -%}
-    <li>units = {{ field.units }}</li>
+  {% if field.unit is not none -%}
+    <li>unit = {{ field.unit }}</li>
   {% endif -%}
 </ul>

--- a/discretisedfield/io/ovf.py
+++ b/discretisedfield/io/ovf.py
@@ -75,7 +75,7 @@ def field_to_ovf(
     """
     filename = pathlib.Path(filename)
     write_dim = 3 if extend_scalar and field.nvdim == 1 else field.nvdim
-    valueunits = " ".join([str(field.units) if field.units else "None"] * write_dim)
+    valueunits = " ".join([str(field.unit) if field.unit else "None"] * write_dim)
     if write_dim == 1:
         valuelabels = "field_x"
     elif extend_scalar:
@@ -309,24 +309,24 @@ def field_from_ovf(filename):
     try:
         unit_list = header["valueunits"].split()
     except KeyError:
-        units = None
+        unit = None
     else:
         if len(unit_list) == 0:
-            units = None  # no unit in the file
+            unit = None  # no unit in the file
         elif len(set(unit_list)) != 1:
             warnings.warn(
                 f"File {filename} contains multiple units for the individual"
                 f" vdims: {unit_list=}. This is not supported by"
-                " discretisedfield. Units are set to None."
+                " discretisedfield. Unit is set to None."
             )
-            units = None
+            unit = None
         else:
-            units = unit_list[0]
+            unit = unit_list[0]
 
     return df.Field(
         mesh,
         dim=header["valuedim"],
         value=array.reshape(r_tuple).transpose(t_tuple),
         vdims=vdims,
-        units=units,
+        unit=unit,
     )

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -2608,7 +2608,10 @@ class TestField:
                 assert np.allclose(fxa.attrs["pmax"], f.mesh.region.pmax)
                 for i in "xyz":
                     assert np.array_equal(getattr(f.mesh.points, i), fxa[i].values)
-                    assert fxa[i].attrs["units"] == f.mesh.attributes["unit"]
+                    assert (
+                        fxa[i].attrs["units"]
+                        == f.mesh.region.units[f.mesh.region.dims.index(i)]
+                    )
                 assert all(fxa["comp"].values == f.vdims)
                 assert np.array_equal(f.array, fxa.values)
 
@@ -2622,7 +2625,10 @@ class TestField:
                 assert np.allclose(fxa.attrs["pmax"], f.mesh.region.pmax)
                 for i in "xyz":
                     assert np.array_equal(getattr(f.mesh.points, i), fxa[i].values)
-                    assert fxa[i].attrs["units"] == f.mesh.attributes["unit"]
+                    assert (
+                        fxa[i].attrs["units"]
+                        == f.mesh.region.units[f.mesh.region.dims.index(i)]
+                    )
                 assert "comp" not in fxa.dims
                 assert np.array_equal(f.array.squeeze(axis=-1), fxa.values)
 
@@ -2641,7 +2647,7 @@ class TestField:
         assert f3d_xa.attrs["units"] is None
 
         # test name and units
-        f3d_xa_2 = self.pf.to_xarray(name="m", units="A/m")
+        f3d_xa_2 = self.pf.to_xarray(name="m", unit="A/m")
         assert f3d_xa_2.name == "m"
         assert f3d_xa_2.attrs["units"] == "A/m"
 
@@ -2650,16 +2656,16 @@ class TestField:
             ["m", 42.0],
             [21.0, 42],
             [21, "A/m"],
-            [{"name": "m"}, {"units": "A/m"}],
+            [{"name": "m"}, {"unit": "A/m"}],
             [["m"], ["A/m"]],
             [["m", "A/m"], None],
             [("m", "A/m"), None],
-            [{"name": "m", "units": "A/m"}, None],
+            [{"name": "m", "unit": "A/m"}, None],
         ]
 
-        for name, units in args:
+        for name, unit in args:
             with pytest.raises(TypeError):
-                self.pf.to_xarray(name, units)
+                self.pf.to_xarray(name, unit)
 
     def test_from_xarray_valid_args(self):
         for mesh in self.meshes:

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -22,7 +22,7 @@ html_re = (
     rf"<li>{mesh_html_re}</li>\s*"
     r"<li>nvdim = \d+</li>\s*"
     r"(<li>vdims:\s*<ul>(<li>.*</li>\s*)+</ul>\s*</li>)?\s*"
-    r"(<li>units = .+</li>)?\s*"
+    r"(<li>unit = .+</li>)?\s*"
     r"</ul>"
 )
 
@@ -41,8 +41,8 @@ def check_field(field):
     )
     if field.vdims:
         pattern = pattern[:-3] + r", vdims: \(.+\)\)$"
-    if field.units is not None:
-        pattern = pattern[:-3] + r", units=.+\)$"
+    if field.unit is not None:
+        pattern = pattern[:-3] + r", unit=.+\)$"
     assert re.search(pattern, rstr)
 
     assert isinstance(field._repr_html_(), str)
@@ -327,22 +327,22 @@ class TestField:
             check_field(fab)
             assert fab.vdims == ["a", "b"]
 
-    def test_units(self):
-        assert self.pf.units is None
+    def test_unit(self):
+        assert self.pf.unit is None
         mesh = self.pf.mesh
-        field = df.Field(mesh, nvdim=3, value=(1, 2, 3), units="A/m")
+        field = df.Field(mesh, nvdim=3, value=(1, 2, 3), unit="A/m")
         check_field(field)
-        assert field.units == "A/m"
-        field.units = "mT"
-        assert field.units == "mT"
+        assert field.unit == "A/m"
+        field.unit = "mT"
+        assert field.unit == "mT"
         with pytest.raises(TypeError):
-            field.units = 3
-        assert field.units == "mT"
-        field.units = None
-        assert field.units is None
+            field.unit = 3
+        assert field.unit == "mT"
+        field.unit = None
+        assert field.unit is None
 
         with pytest.raises(TypeError):
-            df.Field(mesh, nvdim=1, units=1)
+            df.Field(mesh, nvdim=1, unit=1)
 
     def test_value(self):
         p1 = (0, 0, 0)
@@ -1664,14 +1664,14 @@ class TestField:
             (2, lambda point: (point[0], point[1] + point[2])),
             (3, lambda point: (point[0], point[1], point[2])),
         ]:
-            f = df.Field(mesh, nvdim=nvdim, value=value, units="A/m")
+            f = df.Field(mesh, nvdim=nvdim, value=value, unit="A/m")
             for rep in representations:
                 tmpfilename = tmp_path / filename
                 f.write(tmpfilename, representation=rep)
                 f_read = df.Field.fromfile(tmpfilename)
 
                 assert f.allclose(f_read)
-                assert f_read.units == "A/m"
+                assert f_read.unit == "A/m"
                 assert f.mesh.subregions == f_read.mesh.subregions
 
                 tmpfilename = tmp_path / f"no_sr_{filename}"
@@ -1679,7 +1679,7 @@ class TestField:
                 f_read = df.Field.fromfile(tmpfilename)
 
                 assert f.allclose(f_read)
-                assert f_read.units == "A/m"
+                assert f_read.unit == "A/m"
                 assert f_read.mesh.subregions == {}
 
             # Directly write with wrong representation (no data is written)
@@ -1687,13 +1687,13 @@ class TestField:
                 df.io.field_to_ovf(f, "fname.ovf", representation="bin5")
 
         # multiple different units (not supported by discretisedfield)
-        f = df.Field(mesh, nvdim=3, value=(1, 1, 1), units="m s kg")
+        f = df.Field(mesh, nvdim=3, value=(1, 1, 1), unit="m s kg")
         tmpfilename = str(tmp_path / filename)
         f.write(tmpfilename, representation=rep)
         f_read = df.Field.fromfile(tmpfilename)
 
         assert f.allclose(f_read)
-        assert f_read.units is None
+        assert f_read.unit is None
 
         # Extend scalar
         for rep in representations:


### PR DESCRIPTION
Renames: units -> unit

We should maybe also rename the input argument for `to_xarray`.