### PR TITLE
Remove extra attributes when setting subregions

### DIFF
--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -105,23 +105,20 @@ def check_hv(plot, types):
 @pytest.fixture
 def test_field():
     mesh = df.Mesh(p1=(-5e-9, -5e-9, -5e-9), p2=(5e-9, 5e-9, 5e-9), n=(5, 5, 5))
+    c_array = mesh.coordinate_field().array
 
-    def norm_fun(point):
-        x, y, z = point
-        if x**2 + y**2 <= (5e-9) ** 2:
-            return 1e5
-        else:
-            return 0
+    def norm(points):
+        return np.where(
+            (points[..., 0] ** 2 + points[..., 1] ** 2) <= 5e-9**2, 1e5, 0
+        )[..., np.newaxis]
 
-    def value_fun(point):
-        x, y, z = point
-        if x <= 0:
-            return (0, 0, 1)
-        else:
-            return (0, 0, -1)
+    def value(points):
+        res = np.zeros((*mesh.n, 3))
+        res[..., 2] = np.where(points[..., 0] <= 0, 1, -1)
+        return res
 
     return df.Field(
-        mesh, nvdim=3, value=value_fun, norm=norm_fun, vdims=["a", "b", "c"]
+        mesh, nvdim=3, value=value(c_array), norm=norm(c_array), vdims=["a", "b", "c"]
     )
 
 

--- a/discretisedfield/tests/test_mesh.py
+++ b/discretisedfield/tests/test_mesh.py
@@ -126,6 +126,34 @@ def test_init_subregions():
     assert mesh.subregions == subregions
 
 
+def test_subregions_custom_parameters():
+    p1 = (0, 0, 0)
+    p2 = (100, 50, 10)
+    dims = list("abc")
+    units = ["d", "ef", "ghi"]
+    region = df.Region(p1=p1, p2=p2, dims=dims, units=units, tolerance_factor=1e-6)
+    subregions = {
+        "r1": df.Region(p1=(0, 0, 0), p2=(50, 50, 10)),
+        "r2": df.Region(
+            p1=(50, 0, 0),
+            p2=(100, 50, 10),
+            dims=list("rst"),
+            units=list("aei"),
+            tolerance_factor=10,
+        ),
+    }
+    cell = (10, 10, 10)
+    mesh = df.Mesh(region=region, cell=cell, subregions=subregions)
+    assert isinstance(mesh, df.Mesh)
+    assert len(mesh.subregions) == len(subregions)
+    for sr_name in mesh.subregions:
+        assert mesh.subregions[sr_name].pmin == subregions[sr_name].pmin
+        assert mesh.subregions[sr_name].pmax == subregions[sr_name].pmax
+        assert mesh.subregions[sr_name].units == mesh.region.units
+        assert mesh.subregions[sr_name].dims == mesh.region.dims
+        assert mesh.subregions[sr_name].tolerance_factor == mesh.region.tolerance_factor
+
+
 @pytest.mark.parametrize(
     "subregions, error",
     [

--- a/discretisedfield/tests/test_mesh.py
+++ b/discretisedfield/tests/test_mesh.py
@@ -147,8 +147,8 @@ def test_subregions_custom_parameters():
     assert isinstance(mesh, df.Mesh)
     assert len(mesh.subregions) == len(subregions)
     for sr_name in mesh.subregions:
-        assert mesh.subregions[sr_name].pmin == subregions[sr_name].pmin
-        assert mesh.subregions[sr_name].pmax == subregions[sr_name].pmax
+        assert np.array_equal(mesh.subregions[sr_name].pmin, subregions[sr_name].pmin)
+        assert np.array_equal(mesh.subregions[sr_name].pmax, subregions[sr_name].pmax)
         assert mesh.subregions[sr_name].units == mesh.region.units
         assert mesh.subregions[sr_name].dims == mesh.region.dims
         assert mesh.subregions[sr_name].tolerance_factor == mesh.region.tolerance_factor


### PR DESCRIPTION
Only `pmin` and `pmax` are meaningful for subregions. All other attributes (e.g. dims) will be changed to the values of `mesh.region`.

Needs #234 