### PR TITLE
Utility method to convert valid to field.

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -532,6 +532,10 @@ class Field(_FieldIO):
         self._valid = _as_array(valid, self.mesh, nvdim=1, dtype=bool)[..., 0]
 
     @property
+    def _valid_as_field(self):
+        return self.__class__(self.mesh, nvdim=1, value=self.valid, dtype=bool)
+
+    @property
     def vdim_mapping(self):
         """Map vdims to dims."""
         return self._vdim_mapping

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -430,14 +430,21 @@ def test_valid_single_value(valid_mesh, nvdim):
     assert np.array_equal(f.valid.shape, valid_mesh.n)
     assert f.valid.dtype == bool
     assert np.all(f.valid)
+    assert f.mesh == f._valid_as_field.mesh
+    assert f.valid.dtype == f._valid_as_field.array.dtype
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
     # Constant
     f = df.Field(valid_mesh, nvdim=nvdim, valid=True)
     assert np.array_equal(f.valid.shape, valid_mesh.n)
     assert np.all(f.valid)
+    assert f.mesh == f._valid_as_field.mesh
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
     f = df.Field(valid_mesh, nvdim=nvdim, valid=False)
     assert np.array_equal(f.valid.shape, valid_mesh.n)
     assert f.valid.dtype == bool
     assert np.all(~f.valid)
+    assert f.mesh == f._valid_as_field.mesh
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
@@ -457,6 +464,8 @@ def test_valid_set_on_norm(ndim, nvdim):
     f = df.Field(mesh, nvdim=nvdim, value=(1,) * nvdim, norm=norm_func, valid="norm")
     assert np.array_equal(f.valid.shape, mesh.n)
     assert f.valid.dtype == bool
+    assert f.mesh == f._valid_as_field.mesh
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
     for idx in f.mesh.indices:
         if all(f.mesh.index2point(idx) < 5):
             # Use [0] to examine single element numpy array
@@ -480,6 +489,8 @@ def test_valid_set_call(ndim, nvdim):
     f = df.Field(mesh, nvdim=nvdim, valid=valid_func)
     assert np.array_equal(f.valid.shape, mesh.n)
     assert f.valid.dtype == bool
+    assert f.mesh == f._valid_as_field.mesh
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
     for idx in f.mesh.indices:
         if all(f.mesh.index2point(idx) < 5):
             assert f.valid[tuple(idx)]
@@ -495,6 +506,8 @@ def test_valid_set_call(ndim, nvdim):
     f = df.Field(mesh, nvdim=nvdim, valid=valid_func)
     assert np.array_equal(f.valid.shape, mesh.n)
     assert f.valid.dtype == bool
+    assert f.mesh == f._valid_as_field.mesh
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
     for idx in f.mesh.indices:
         if all(f.mesh.index2point(idx) < 5):
             assert f.valid[tuple(idx)]
@@ -518,6 +531,8 @@ def test_valid_array(ndim, nvdim):
 
     f = df.Field(mesh, nvdim=nvdim, valid=expected_valid)
     assert np.all(expected_valid == f.valid)
+    assert f.mesh == f._valid_as_field.mesh
+    assert np.array_equal(f.valid, f._valid_as_field.array.squeeze(axis=-1))
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -417,10 +417,7 @@ def test_unit(test_field):
         df.Field(mesh, nvdim=1, unit=1)
 
 
-@pytest.mark.parametrize(
-    "nvdim",
-    [1, 2, 3, 4],
-)
+@pytest.mark.parametrize("nvdim", [1, 2, 3, 4])
 def test_valid_single_value(valid_mesh, nvdim):
     # Default
     f = df.Field(
@@ -448,10 +445,7 @@ def test_valid_single_value(valid_mesh, nvdim):
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
-@pytest.mark.parametrize(
-    "nvdim",
-    [1, 2, 3, 4],
-)
+@pytest.mark.parametrize("nvdim", [1, 2, 3, 4])
 def test_valid_set_on_norm(ndim, nvdim):
     mesh = df.Mesh(p1=(0,) * ndim, p2=(10,) * ndim, cell=(1,) * ndim)
 
@@ -475,10 +469,7 @@ def test_valid_set_on_norm(ndim, nvdim):
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
-@pytest.mark.parametrize(
-    "nvdim",
-    [1, 2, 3, 4],
-)
+@pytest.mark.parametrize("nvdim", [1, 2, 3, 4])
 def test_valid_set_call(ndim, nvdim):
     mesh = df.Mesh(p1=(0,) * ndim, p2=(10,) * ndim, cell=(1,) * ndim)
 
@@ -516,10 +507,7 @@ def test_valid_set_call(ndim, nvdim):
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
-@pytest.mark.parametrize(
-    "nvdim",
-    [1, 2, 3, 4],
-)
+@pytest.mark.parametrize("nvdim", [1, 2, 3, 4])
 def test_valid_array(ndim, nvdim):
     mesh = df.Mesh(p1=(0,) * ndim, p2=(10,) * ndim, cell=(1,) * ndim)
 
@@ -536,10 +524,7 @@ def test_valid_array(ndim, nvdim):
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
-@pytest.mark.parametrize(
-    "nvdim",
-    [1, 2, 3, 4],
-)
+@pytest.mark.parametrize("nvdim", [1, 2, 3, 4])
 def test_valid_operators(ndim, nvdim):
     mesh = df.Mesh(p1=(0,) * ndim, p2=(10,) * ndim, cell=(1,) * ndim)
 


### PR DESCRIPTION
Required e.g. for plotting (and filtering based on `valid` instead of the norm) where a field is expected (and beneficial).