### PR TITLE
Fix ovf extend scalar

### DIFF
--- a/discretisedfield/io/ovf.py
+++ b/discretisedfield/io/ovf.py
@@ -112,7 +112,7 @@ class _FieldIO_OVF:
 
                 # processing in chuncks to reduce memory consumption
                 chunksize = 100_000
-                n_chunks = math.ceil(len(self.array.flat) / chunksize)
+                n_chunks = math.ceil(len(reordered.flat) / chunksize)
                 for i in range(n_chunks):
                     f.write(
                         np.asarray(

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -2467,8 +2467,10 @@ def test_write_read_ovf(tmp_path):
 
     # Extend scalar
     for rep in representations:
-        f = df.Field(mesh, nvdim=1, value=lambda point: point[0] + point[1] + point[2])
-        tmpfilename = tmp_path / filename
+        # large mesh required to detect bugs when saving data in chunks
+        large_mesh = df.Mesh(p1=(0, 0, 0), p2=(1, 1, 1), n=(480, 200, 12))
+        f = df.Field(large_mesh, nvdim=1, value=1)
+        tmpfilename = tmp_path / "extended-scalar.ovf"
         f.to_file(tmpfilename, representation=rep, extend_scalar=True)
         f_read = df.Field.from_file(tmpfilename)
 


### PR DESCRIPTION
OVF files saved with the option `extend_scalar=True` (saving a scalar field as the x component of a vector field) only contain a part of the data when the array size exceeds 100_000 elements (the chunk size).

This PR fixes the bug and updates the test that should detect it (which it now does).