### PR TITLE
Fix: valid initialisation

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -546,7 +546,7 @@ class Field(_FieldIO):
     @valid.setter
     def valid(self, valid):
         if valid is not None:
-            if valid == "norm":
+            if isinstance(valid, str) and valid == "norm":
                 valid = ~np.isclose(self.norm.array, 0)
         else:
             valid = True


### PR DESCRIPTION
When setting valid using a numpy array the comparisons with 'norm' would be done element-wise.