### PR TITLE
Fix: mesh comparison for numerical operations

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -1185,7 +1185,7 @@ class Field(_FieldIO):
         if not isinstance(other, self.__class__):
             raise TypeError(f"Object of type {type(other)} not supported.")
 
-        if self.mesh != other.mesh:
+        if not self.mesh.allclose(other.mesh):
             raise ValueError(
                 "To perform this operation both fields must have the same mesh."
             )


### PR DESCRIPTION
The checks for the mesh did not take limited numerical precision into account. I think this is a left-over from the refactoring.