### PR TITLE
Specify minimum required VTK version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "scipy>=1.6",
     "sympy>=1.10.1",
     "jinja2",
-    "vtk",
+    "vtk>=9.1",
     "xarray",
     "hvplot"
 ]


### PR DESCRIPTION
The VTK <-> numpy conversion, which is part of VTK, did use a deprecated `numpy.bool` that has been removed from recent numpy versions. This has been updated in VTK 9.1 (https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8234).