### PR TITLE
Use field.valid in Hv plotting

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3499,6 +3499,9 @@ class Field(_FieldIO):
         also callable to quickly generate plots. For more details and the
         available methods refer to the documentation linked below.
 
+        Data shown in the plot is automatically filtered using the `valid` property of
+        the field.
+
         .. seealso::
 
             :py:func:`~discretisedfield.plotting.Hv.__call__`

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3527,7 +3527,9 @@ class Field(_FieldIO):
     def _hv_data_selection(self, **kwargs):
         """Select field part as specified by the input arguments."""
         vdims = kwargs.pop("vdims") if "vdims" in kwargs else None
-        res = self.to_xarray().sel(**kwargs, method="nearest")
+        xrfield = self.to_xarray().copy()  # create copy to avoid changing field values
+        xrfield.data[~self.valid] = np.nan
+        res = xrfield.sel(**kwargs, method="nearest")
         if vdims:
             res = res.sel(vdims=vdims)
         return res

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3527,7 +3527,9 @@ class Field(_FieldIO):
     def _hv_data_selection(self, **kwargs):
         """Select field part as specified by the input arguments."""
         vdims = kwargs.pop("vdims") if "vdims" in kwargs else None
-        xrfield = self.to_xarray().copy()  # create copy to avoid changing field values
+        xrfield = self.to_xarray().copy()
+        # we create copy to avoid changing field values
+        # using np.where instead did cause issues with broadcasting
         xrfield.data[~self.valid] = np.nan
         res = xrfield.sel(**kwargs, method="nearest")
         if vdims:

--- a/discretisedfield/plotting/__init__.py
+++ b/discretisedfield/plotting/__init__.py
@@ -8,6 +8,3 @@ from discretisedfield.plotting.mpl import add_colorwheel
 from discretisedfield.plotting.mpl_field import MplField
 from discretisedfield.plotting.mpl_mesh import MplMesh
 from discretisedfield.plotting.mpl_region import MplRegion
-
-"""Default settings for plotting."""
-defaults = util.Defaults(Hv)

--- a/discretisedfield/plotting/hv.py
+++ b/discretisedfield/plotting/hv.py
@@ -20,12 +20,6 @@ class Hv:
     created for the directions not shown in the plot. This class should not be accessed
     directly. Use ``field.hv`` to use the different plotting methods.
 
-    Hv has a class property ``norm_filter`` that controls the default behaviour of
-    ``Hv.__call__``, the convenience plotting method that is typically available as
-    ``field.hv()``. By default ``norm_filter=True`` and plots created with ``hv()`` use
-    automatic filtering based on the norm of the field. To disable automatic filtering
-    globally use ``discretisedfield.plotting.defaults.norm_filter = False``.
-
     Parameters
     ----------
     key_dims : dict[df.plotting.util.hv_key_dim]
@@ -48,8 +42,6 @@ class Hv:
 
     """
 
-    _norm_filter = True
-
     def __init__(self, key_dims, callback, vdim_guess_callback=None):
         # no tests for key_dims and callback as the class is not directly used by users
         if not hv.extension._loaded:
@@ -63,7 +55,6 @@ class Hv:
         kdims,
         vdims=None,
         roi=None,
-        norm_filter=None,
         scalar_kw=None,
         vector_kw=None,
     ):
@@ -98,11 +89,6 @@ class Hv:
         ``roi`` is 0. It relies on ``xarray``s broadcasting and the object passed to
         ``roi`` must only have the same dimensions as the ones specified as ``kdims``.
 
-        To disable filtering pass ``norm_filter=False``. To disable filtering for all
-        plots globally set ``discretisedfield.plotting.defaults.norm_filter = False``.
-        If norm filtering has been disabled globally use ``norm_filter=True`` to enable
-        it for a single plot.
-
         All default values of ``hv.scalar`` and ``hv.vector`` can be changed by passing
         dictionaries to ``scalar_kw`` and ``vector_kw``, which are then used in
         subplots.
@@ -136,13 +122,6 @@ class Hv:
 
             Filter out certain areas in the plot. Only cells where the roi is non-zero
             are included in the output.
-
-        norm_filter : bool, optional
-
-            If ``True`` use a default roi based on the norm of the field, if ``False``
-            do not filter automatically. If not specified the value of
-            ``discretisedfield.plotting.defaults.norm_filter`` is used. This allows
-            globally disabling the filtering.
 
         scalar_kw : dict
 
@@ -179,12 +158,6 @@ class Hv:
         """
         scalar_kw = {} if scalar_kw is None else scalar_kw.copy()
         vector_kw = {} if vector_kw is None else vector_kw.copy()
-
-        if norm_filter or (norm_filter is None and self._norm_filter):
-            if roi is None:
-                roi = self.callback
-            scalar_kw.setdefault("roi", roi)
-            vector_kw.setdefault("roi", roi)
 
         vector_kw.setdefault("use_color", False)
 

--- a/discretisedfield/plotting/hv.py
+++ b/discretisedfield/plotting/hv.py
@@ -20,6 +20,9 @@ class Hv:
     created for the directions not shown in the plot. This class should not be accessed
     directly. Use ``field.hv`` to use the different plotting methods.
 
+    Data in the plots is filtered based on ``field.valid``. Only cells where
+    ``valid==True`` are visible in the plots.
+
     Parameters
     ----------
     key_dims : dict[df.plotting.util.hv_key_dim]

--- a/discretisedfield/plotting/util.py
+++ b/discretisedfield/plotting/util.py
@@ -3,50 +3,6 @@ import colorsys
 
 import numpy as np
 
-
-class Defaults:
-    """Default settings for plotting."""
-
-    _defaults = {
-        "norm_filter": True,
-    }
-
-    def __init__(self, *classes):
-        self._classes = classes
-        self.reset()
-
-    def reset(self):
-        """Reset values to their defaults."""
-        for setting in self:
-            setattr(self, setting, self._defaults[setting])
-
-    def __repr__(self):
-        summary = "plotting defaults\n"
-        for setting in self._defaults:
-            summary += f"  {setting}: {getattr(self, setting)}\n"
-        return summary
-
-    def __getattr__(self, attr):
-        if attr not in self:
-            raise AttributeError(
-                f"{self.__class__.__name__!r} object has no attribute {attr!r}."
-            )
-        return getattr(self, f"_{attr}")
-
-    def __setattr__(self, attr, value):
-        if attr in self:
-            attr = f"_{attr}"
-            for class_ in self._classes:
-                setattr(class_, attr, value)
-        super().__setattr__(attr, value)
-
-    def __iter__(self):
-        yield from self._defaults
-
-    def __dir__(self):
-        return dir(self.__class__) + list(self)
-
-
 # Color pallete as hex and int.
 cp_hex = [
     "#4c72b0",

--- a/discretisedfield/tests/test_plotting.py
+++ b/discretisedfield/tests/test_plotting.py
@@ -1,31 +1,7 @@
 import numpy as np
-import pytest
 
 import discretisedfield as df
 import discretisedfield.plotting.util as plot_util
-
-
-def test_defaults():
-    # default settings
-    assert df.plotting.defaults.norm_filter
-    assert df.plotting.Hv._norm_filter
-    assert repr(df.plotting.defaults) == "plotting defaults\n  norm_filter: True\n"
-
-    assert list(df.plotting.defaults) == ["norm_filter"]
-    assert all(key in dir(df.plotting.defaults) for key in df.plotting.defaults)
-
-    with pytest.raises(AttributeError):
-        df.plotting.defaults.nonexisting
-
-    # disable norm filtering
-    df.plotting.defaults.norm_filter = False
-    assert not df.plotting.defaults.norm_filter
-    assert not df.plotting.Hv._norm_filter
-
-    # enable norm filtering
-    df.plotting.defaults.reset()
-    assert df.plotting.defaults.norm_filter
-    assert df.plotting.Hv._norm_filter
 
 
 def test_inplane_angle():


### PR DESCRIPTION
This would replace #451 and ubermag/micromagneticdata#54

The `_hv_data_selection` only returns valid data and sets all other values in the returned xarray to `nan`.


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `_hv_data_selection` method to create a copy of the `xrfield` variable and set all invalid data points to `nan`. This ensures only valid data is returned when selecting a field part.
- New Feature: Enhanced the `hv` method to automatically filter data using the `valid` property of the field. The plots generated will now only display valid data.
- Refactor: Removed the `norm_filter` property from the `Hv` class and its parameter from the `__call__` method, simplifying the code structure.
- Chore: Removed unused import statements for `MplField`, `MplMesh`, and `MplRegion`.
- Refactor: Eliminated the `Defaults` class, indicating a refactoring of default settings for plotting.
- Test: Removed the `test_defaults` function and a test case within the `test_inplane_angle` function, aligning with the updated plotting module.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->