### PR TITLE
IO for ovf and vtk

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -3408,6 +3408,11 @@ class Field(_FieldIO):
         1000
 
         """
+        if self.mesh.region.ndim != 3:
+            raise RuntimeError(
+                "Conversion to VTK RectilinearGrid is only possible for 'ndim=3', not"
+                f" {self.mesh.region.ndim=}"
+            )
         if self.nvdim > 1 and self.vdims is None:
             raise AttributeError(
                 "Field vdims must be assigned before converting to vtk."

--- a/discretisedfield/io/ovf.py
+++ b/discretisedfield/io/ovf.py
@@ -18,6 +18,11 @@ class _FieldIO_OVF:
     def _to_ovf(
         self, filename, representation="bin8", extend_scalar=False, save_subregions=True
     ):
+        if self.mesh.region.ndim != 3:
+            raise RuntimeError(
+                "OVF files can only store fields with 'ndim=3', not"
+                f" {self.mesh.region.ndim=}."
+            )
         filename = pathlib.Path(filename)
         write_dim = 3 if extend_scalar and self.nvdim == 1 else self.nvdim
         valueunits = " ".join([str(self.unit) if self.unit else "None"] * write_dim)

--- a/discretisedfield/io/vtk.py
+++ b/discretisedfield/io/vtk.py
@@ -29,11 +29,14 @@ class _FieldIO_VTK:
             writer.SetFileTypeToBinary()
         # xml has no distinction between ascii and binary
 
+        writer.SetFileName(str(filename))
+        # Convert field to VTK before writing subregion information because
+        # to_vtk will fail if ndim is not correct
+        writer.SetInputData(self.to_vtk())
+
         if save_subregions and self.mesh.subregions:
             self.mesh.save_subregions(filename)
 
-        writer.SetFileName(str(filename))
-        writer.SetInputData(self.to_vtk())
         writer.Write()
 
     @classmethod

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -2649,8 +2649,6 @@ def test_rotate90():
     assert np.allclose(field.mean(), (1, 3, -2))
 
 
-# ######################################
-# TODO Martin
 def test_write_read_ovf(tmp_path):
     representations = ["txt", "bin4", "bin8"]
     filename = "testfile.ovf"
@@ -2832,6 +2830,16 @@ def test_write_read_vtk(tmp_path):
     f._vdims = None  # manually remove component labels
     with pytest.raises(AttributeError):
         f.to_file(str(tmp_path / filename))
+
+
+@pytest.mark.parametrize("extension", ["ovf", "vtk"])
+@pytest.mark.parametrize("ndim", [1, 2, 4])
+def test_write_invalid_ndim(ndim, extension):
+    mesh = df.Mesh(p1=[0] * ndim, p2=[1] * ndim, n=[10] * ndim)
+    field = df.Field(mesh, nvdim=1)
+
+    with pytest.raises(RuntimeError):
+        field.to_file(f"field.{extension}")
 
 
 @pytest.mark.parametrize("nvdim,value", [(1, -1.23), (3, (1e-3 + np.pi, -5e6, 6e6))])


### PR DESCRIPTION
- Raise `RuntimeError` if `ndim!=3` (not supported in ovf or vtk RectilinearGrid)
- Add additional tests
- Review tests for `ndim=3` (no changes)