### PR TITLE
build(deps): remove jupyter lab as dependency, update holoviews

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,18 +36,17 @@ classifiers = [
 ]
 
 dependencies = [
-    "ubermagutil>=0.63.0",
-    "pandas>=1.1",
-    "matplotlib>=3.3, !=3.7.2",
-    "jupyterlab~=3.0",
     "h5py>=3.1",
+    "holoviews",
+    "jinja2",
     "k3d>=2.11",
+    "matplotlib>=3.3, !=3.7.2",
+    "pandas>=1.1",
     "scipy>=1.6",
     "sympy>=1.10.1",
-    "jinja2",
+    "ubermagutil>=0.63.0",
     "vtk>=9.1",
-    "xarray",
-    "hvplot"
+    "xarray"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Jupyter lab is not directly required as a dependency. We move the dependency to the ubermag metapackage, which is our "end-user application".

- We still had `hvplot` as dependency but only use `HoloViews`.