### PR TITLE
fix: RuntimeWarning in lightness plot

### DIFF
--- a/discretisedfield/plotting/mpl_field.py
+++ b/discretisedfield/plotting/mpl_field.py
@@ -474,8 +474,8 @@ class MplField(Mpl):
         rgba = np.empty((*rgb.shape[:-1], 4))
         rgba[..., :3] = rgb
         rgba[..., 3] = 1.0
-        rgba[..., 3][np.isnan(rgb[..., 0])] = 0
-        rgba[..., :3][np.isnan(rgb[..., 0])] = 0  # nan -> zero to avoid cast warning
+        # nan -> zero with alpha=0 to avoid cast warning
+        rgba[np.isnan(rgb[..., 0])] = 0
 
         kwargs["cmap"] = "hsv"  # only hsv cmap allowed
         ax.imshow(

--- a/discretisedfield/plotting/mpl_field.py
+++ b/discretisedfield/plotting/mpl_field.py
@@ -475,6 +475,7 @@ class MplField(Mpl):
         rgba[..., :3] = rgb
         rgba[..., 3] = 1.0
         rgba[..., 3][np.isnan(rgb[..., 0])] = 0
+        rgba[..., :3][np.isnan(rgb[..., 0])] = 0  # nan -> zero to avoid cast warning
 
         kwargs["cmap"] = "hsv"  # only hsv cmap allowed
         ax.imshow(

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -3086,7 +3086,7 @@ def test_mpl_dimension_lightness(valid_mesh, nvdim):
 
 
 @pytest.mark.filterwarnings("error")
-def test_mpl_lightness_valid(test_field, tmp_path):
+def test_mpl_lightness_handles_invalid_parts(test_field, tmp_path):
     """
     We did set rgb values in invalid parts to np.nan. The array is internally converted
     to dtype np.uint8. The nan values result in a warning.

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -3085,6 +3085,18 @@ def test_mpl_dimension_lightness(valid_mesh, nvdim):
     plt.close("all")
 
 
+@pytest.mark.filterwarnings("error")
+def test_mpl_lightness_valid(test_field, tmp_path):
+    """
+    We did set rgb values in invalid parts to np.nan. The array is internally converted
+    to dtype np.uint8. The nan values result in a warning.
+    To avoid this we now set invalid parts to zero.
+    """
+    assert (~test_field.valid).any()
+    # save field to trigger the warning
+    test_field.sel("z").mpl.lightness(filename=str(tmp_path / "test.pdf"))
+
+
 @pytest.mark.filterwarnings("ignore:Automatic coloring")
 def test_mpl_vector(test_field):
     # No axes
@@ -3616,7 +3628,7 @@ def test_hv_scalar_ndim(ndim, nvdim):
     check_hv(field.hv.scalar(kdims=list(field.mesh.region.dims[:2])), reference)
 
 
-@pytest.mark.filterwarning("ignore:Automatic coloring")
+@pytest.mark.filterwarnings("ignore:Automatic coloring")
 @pytest.mark.parametrize("ndim", range(2, 5))
 @pytest.mark.parametrize("nvdim", range(2, 5))
 def test_hv_vector_ndim(ndim, nvdim):


### PR DESCRIPTION
The warning originates from the cast from float to int (inside matplotlib) when there are invalid parts in the field. We did set those to np.nan and get a warning about invalid values in the cast to uint8.