### PR TITLE
Use ruff for pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 default_language_version:
   python: python3.8
 
+exclude: 'dev'
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
@@ -12,26 +14,16 @@ repos:
 #    args: [--markdown-linebreak-ext=md]
 #    exclude: 'discretisedfield/tests/test_sample/.*'
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.11
   hooks:
-  - id: isort
-
-- repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.7.0
-  hooks:
-  - id: nbqa-isort  # isort inside Jupyter notebooks
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.1.0
-  hooks:
-  - id: flake8
-    additional_dependencies: [flake8-rst-docstrings]  #, flake8-docstrings]
-
-- repo: https://github.com/psf/black
-  rev: 23.9.1
-  hooks:
-  - id: black-jupyter
+    # Run the linter.
+    - id: ruff
+      types_or: [ python, pyi, jupyter ]
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]
 
 # - repo: https://github.com/codespell-project/codespell
 #   rev: v2.1.0

--- a/discretisedfield/__init__.py
+++ b/discretisedfield/__init__.py
@@ -1,19 +1,18 @@
 """Finite-difference fields."""
 import importlib.metadata
-import os
 import pathlib
 
 import matplotlib.pyplot as plt
 import pytest
 
-from . import tools
-from .field import Field
-from .field_rotator import FieldRotator
-from .interact import interact
-from .line import Line
-from .mesh import Mesh
-from .operators import integrate
-from .region import Region
+from . import tools  # noqa: F401
+from .field import Field  # noqa: F401
+from .field_rotator import FieldRotator  # noqa: F401
+from .interact import interact  # noqa: F401
+from .line import Line  # noqa: F401
+from .mesh import Mesh  # noqa: F401
+from .operators import integrate  # noqa: F401
+from .region import Region  # noqa: F401
 
 # Enable default plotting style.
 plt.style.use(pathlib.Path(__file__).parent / "plotting" / "plotting-style.mplstyle")

--- a/discretisedfield/html/__init__.py
+++ b/discretisedfield/html/__init__.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 import jinja2

--- a/discretisedfield/plotting/__init__.py
+++ b/discretisedfield/plotting/__init__.py
@@ -1,4 +1,5 @@
 """Matplotlib based plotting."""
+# ruff: noqa: F401
 from discretisedfield.plotting import util
 from discretisedfield.plotting.hv import Hv
 from discretisedfield.plotting.k3d_field import K3dField

--- a/discretisedfield/region.py
+++ b/discretisedfield/region.py
@@ -76,6 +76,7 @@ class Region(_RegionIO):
     ValueError: ...
 
     """
+
     __slots__ = ["_pmin", "_pmax", "_dims", "_units", "_tolerance_factor"]
 
     def __init__(

--- a/discretisedfield/tests/test_field.py
+++ b/discretisedfield/tests/test_field.py
@@ -91,9 +91,9 @@ def test_field():
     # else:
     #     return 0
     def norm(points):
-        return np.where(
-            (points[..., 0] ** 2 + points[..., 1] ** 2) <= 5e-9**2, 1e5, 0
-        )[..., np.newaxis]
+        return np.where((points[..., 0] ** 2 + points[..., 1] ** 2) <= 5e-9**2, 1e5, 0)[
+            ..., np.newaxis
+        ]
 
     # Values are defined in numpy for performance reasons
     # We define vector fields with vx=0, vy=0, vz=+/-1 for x<0 / x>0

--- a/discretisedfield/tools/__init__.py
+++ b/discretisedfield/tools/__init__.py
@@ -1,4 +1,5 @@
 """Convenience tools"""
+# ruff: noqa: F401
 from .tools import (
     count_bps,
     count_large_cell_angle_regions,

--- a/discretisedfield/util/__init__.py
+++ b/discretisedfield/util/__init__.py
@@ -1,1 +1,2 @@
+# ruff: noqa: F401
 from .util import array2tuple, assemble_index, bergluescher_angle, rescale_xarray

--- a/docs/field-operations.ipynb
+++ b/docs/field-operations.ipynb
@@ -2535,15 +2535,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 75,
    "metadata": {},
    "outputs": [],
@@ -2697,7 +2688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.10.12"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,15 +67,11 @@ repository = "https://github.com/ubermag/discretisedfield"
 [project.scripts]
 ovf2vtk = "discretisedfield.io.ovf2vtk:ovf2vtk"
 
-[tool.black]
-experimental-string-processing = true
+[tool.ruff]
+ignore-init-module-imports = true
 
 [tool.coverage.run]
 omit = ["discretisedfield/tests/*"]
-
-[tool.isort]
-profile = "black"
-skip_gitignore = true  # ignores files listed in .gitignore
 
 [tool.setuptools.packages.find]
 include = ["discretisedfield*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ ovf2vtk = "discretisedfield.io.ovf2vtk:ovf2vtk"
 [tool.ruff]
 ignore-init-module-imports = true
 
+[tool.ruff.per-file-ignores]
+"*.ipynb" = ["F811"]  # 'redefined-while-unused'; many false positives in notebooks because ipywidgets decorated functions are not recognised
+
 [tool.coverage.run]
 omit = ["discretisedfield/tests/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ repository = "https://github.com/ubermag/discretisedfield"
 ovf2vtk = "discretisedfield.io.ovf2vtk:ovf2vtk"
 
 [tool.ruff]
-ignore-init-module-imports = true
+ignore-init-module-imports = true  # do not remove unused imports in __init__ and warn instead
 
 [tool.ruff.per-file-ignores]
 "*.ipynb" = ["F811"]  # 'redefined-while-unused'; many false positives in notebooks because ipywidgets decorated functions are not recognised


### PR DESCRIPTION
Ruff can do linting and formatting. We can use it to replace `black`, `isort`, and `flake8`.