### PR TITLE
fix docstring tests

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -4184,8 +4184,7 @@ class Field(_FieldIO):
         ...                                p2=[21., 21., 21.],
         ...                                nvdim=3),)
         >>> xa
-        <xarray.DataArray 'mag' (x: 20, y: 20, z: 20, vdims: 3)>
-        ...
+        <xarray.DataArray 'mag' (x: 20, y: 20, z: 20, vdims: 3)>...
 
         2. Create Field from DataArray
 

--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -4057,14 +4057,12 @@ class Field(_FieldIO):
 
         >>> xa = field.to_xarray()
         >>> xa
-        <xarray.DataArray 'field' (x: 10, y: 10, z: 10, vdims: 3)>
-        ...
+        <xarray.DataArray 'field' (x: 10, y: 10, z: 10, vdims: 3)>...
 
         3. Select values of `x` component
 
         >>> xa.sel(vdims='x')
-        <xarray.DataArray 'field' (x: 10, y: 10, z: 10)>
-        ...
+        <xarray.DataArray 'field' (x: 10, y: 10, z: 10)>...
 
         """
         if not isinstance(name, str):


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- The PR updates the docstrings in `discretisedfield/field.py` to simplify the display of `xarray.DataArray` objects. This change makes the examples more concise and easier to read.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field.py</strong><dd><code>Simplify xarray DataArray display in docstrings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

discretisedfield/field.py
<li>Simplified the display of xarray.DataArray objects in the docstring <br>examples.


</details>
    

  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/520/files#diff-c58c98f0ea2639669e6b8e97bd7e9eedc3cb071080df2e78678b2e70fe76cdd4">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

