### PR TITLE
Use older macOS version with Intel CPU because the OOMMF M1 conda pac…

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.10"]
     defaults:
       run:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,7 @@ jobs:
       uses: pyvista/setup-headless-display-action@v2
 
     - name: Set up conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         auto-update-conda: true


### PR DESCRIPTION
### **User description**
…kage is still missing

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated GitHub Actions CI workflow to use `macos-13` instead of `macos-latest` due to compatibility issues with OOMMF M1 conda package on newer macOS versions.
- Removed unnecessary setup for headless display to simplify the workflow.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow.yml</strong><dd><code>Update macOS version and streamline CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/workflow.yml
<li>Changed macOS version in CI from 'macos-latest' to 'macos-13' to avoid <br>issues with missing OOMMF M1 conda package.<br> <li> Removed setup for headless display in CI workflow.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/528/files#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

