### PR TITLE
correction `infile` to `input` in wildcard point

### DIFF
--- a/docs/ovf2vtk.ipynb
+++ b/docs/ovf2vtk.ipynb
@@ -54,7 +54,7 @@
     "Usually, the number of files which should be converted is very large. In that case, a filename with a wildcard can be used.\n",
     "\n",
     "```\n",
-    "$ ovf2vtk --infile my-ovf-file*.omf\n",
+    "$ ovf2vtk --input my-ovf-file*.omf\n",
     "```"
    ]
   }


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Corrected the command-line argument from `--infile` to `--input` in the `ovf2vtk` documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ovf2vtk.ipynb</strong><dd><code>Update command-line argument in documentation example</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ovf2vtk.ipynb
<li>Corrected the command-line argument from <code>--infile</code> to <code>--input</code> in the <br>documentation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/529/files#diff-a0451348711662bd3579d786c4163a6c687bea7704de859842c5488b47c36a84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

