### PR TITLE
Numpy2

### DIFF
--- a/discretisedfield/field.py
+++ b/discretisedfield/field.py
@@ -331,16 +331,16 @@ class Field(_FieldIO):
         >>> mesh = df.Mesh(p1=p1, p2=p2, cell=cell,\
                            subregions={'s1': sub1, 's2': sub2})
         >>> field = df.Field(mesh, nvdim=1, value={'s1': 1, 's2': 1})
-        >>> (field.array == 1).all()
+        >>> (field.array == 1).all().item()
         True
         >>> field = df.Field(mesh, nvdim=1, value={'s1': 1})
         Traceback (most recent call last):
         ...
         KeyError: ...
         >>> field = df.Field(mesh, nvdim=1, value={'s1': 2, 'default': 1})
-        >>> (field.array == 1).all()
+        >>> (field.array == 1).all().item()
         False
-        >>> (field.array == 0).any()
+        >>> (field.array == 0).any().item()
         False
         >>> mesh = df.Mesh(p1=p1, p2=p2, cell=cell, subregions={'s': sub1})
         >>> field = df.Field(mesh, nvdim=1, value={'s': 1})
@@ -348,7 +348,7 @@ class Field(_FieldIO):
         ...
         KeyError: ...
         >>> field = df.Field(mesh, nvdim=1, value={'default': 1})
-        >>> (field.array == 1).all()
+        >>> (field.array == 1).all().item()
         True
 
         .. seealso:: :py:func:`~discretisedfield.Field.array`

--- a/discretisedfield/html/templates/mesh.jinja2
+++ b/discretisedfield/html/templates/mesh.jinja2
@@ -2,7 +2,7 @@
 <ul>
   {%- set region = mesh.region %}
   <li>{% include 'region.jinja2' %}</li>
-  <li>n = {{ mesh.n|list }}</li>
+  <li>n = {{ mesh.n.tolist() }}</li>
   {%- if mesh.bc %}
     <li>bc = {{ mesh.bc }}</li>
   {%- endif %}

--- a/discretisedfield/html/templates/region.jinja2
+++ b/discretisedfield/html/templates/region.jinja2
@@ -1,7 +1,7 @@
 <strong>Region</strong>{%if region_name is defined %} <i>{{ region_name }}</i>{% endif %}
 <ul>
-  <li>pmin = {{ region.pmin|list }}</li>
-  <li>pmax = {{ region.pmax|list }}</li>
+  <li>pmin = {{ region.pmin.tolist() }}</li>
+  <li>pmax = {{ region.pmax.tolist() }}</li>
   <li>dims = {{ region.dims|list }}</li>
   <li>units = {{ region.units|list }}</li>
 </ul>

--- a/discretisedfield/io/hdf5.py
+++ b/discretisedfield/io/hdf5.py
@@ -73,7 +73,9 @@ class _FieldIO_HDF5:
 
     def _to_hdf5(self, filename):
         """Save a single field in a new hdf5 file."""
-        utc_now = datetime.datetime.utcnow().isoformat(timespec="seconds")
+        utc_now = datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="seconds"
+        )
         with h5py.File(filename, "w") as f:
             f.attrs["ubermag-hdf5-file-version"] = "0.1"
             f.attrs["discretisedfield.__version__"] = df.__version__

--- a/discretisedfield/line.py
+++ b/discretisedfield/line.py
@@ -263,7 +263,7 @@ class Line:
         4.0
 
         """
-        return self.data["r"].iloc[-1]
+        return self.data["r"].iloc[-1].item()
 
     def __repr__(self):
         """Representation string.

--- a/discretisedfield/mesh.py
+++ b/discretisedfield/mesh.py
@@ -2052,7 +2052,8 @@ class Mesh(_MeshIO):
             )
 
         values = np.arange(slider_min, slider_max + 1e-20, slider_step)
-        labels = np.around(values / multiplier, decimals=3)
+        labels = np.around(values / multiplier, decimals=3).tolist()
+        values = values.tolist()
         options = list(zip(labels, values))
 
         # Select middle element for slider value

--- a/discretisedfield/mesh.py
+++ b/discretisedfield/mesh.py
@@ -850,7 +850,8 @@ class Mesh(_MeshIO):
         # If index is rounded to the out-of-range values.
         index = np.clip(index, 0, self.n - 1)
 
-        return tuple(index)
+        # conversion to list is required to convert the datatypes to Python builtins
+        return tuple(index.tolist())
 
     def region2slices(self, region):
         """Slices of indices that correspond to cells contained in the region.
@@ -1501,7 +1502,7 @@ class Mesh(_MeshIO):
             )
         if len(attr) > 1 and attr[0] == "d":
             with contextlib.suppress(ValueError):
-                return self.cell[self.region._dim2index(attr[1:])]
+                return self.cell.tolist()[self.region._dim2index(attr[1:])]
         raise AttributeError(f"Object has no attribute {attr}.")
 
     def __dir__(self):
@@ -1544,7 +1545,7 @@ class Mesh(_MeshIO):
         8.0
 
         """
-        return np.prod(self.cell)
+        return np.prod(self.cell).item()
 
     def scale(self, factor, reference_point=None, inplace=False):
         """Scale the underlying region and all subregions.

--- a/discretisedfield/plotting/hv.py
+++ b/discretisedfield/plotting/hv.py
@@ -733,8 +733,11 @@ class Hv:
         if n is None:
             return array
 
+        # .item() is required to convert xarray to Python built-in type;
+        # without this conversion linspace will fail because it would try to create a
+        # a new xarray but no dimensions are provided.
         vals = {
-            dim: np.linspace(array[dim].min(), array[dim].max(), ni)
+            dim: np.linspace(array[dim].min().item(), array[dim].max().item(), ni)
             for dim, ni in zip(kdims, n)
         }
         resampled = array.sel(**vals, method="nearest")

--- a/discretisedfield/region.py
+++ b/discretisedfield/region.py
@@ -460,7 +460,7 @@ class Region(_RegionIO):
         100
 
         """
-        return np.prod(self.edges)
+        return np.prod(self.edges).item()
 
     def __repr__(self):
         r"""Representation string.

--- a/discretisedfield/tools/tools.py
+++ b/discretisedfield/tools/tools.py
@@ -657,10 +657,11 @@ def count_bps(field, /, direction):
     bp_count = bp_number[1:] - bp_number[:-1]
 
     results = {}
-    results["bp_number"] = abs(bp_count).sum()
-    results["bp_number_hh"] = abs(bp_count[bp_count < 0].sum())
-    results["bp_number_tt"] = bp_count[bp_count > 0].sum()
+    results["bp_number"] = abs(bp_count).sum().item()
+    results["bp_number_hh"] = abs(bp_count[bp_count < 0].sum()).item()
+    results["bp_number_tt"] = bp_count[bp_count > 0].sum().item()
 
+    bp_number = bp_number.tolist()
     # pattern = list([<local BP_count>, <repetitions>])
     pattern = [[bp_number[0], 1]]
     for q_val in bp_number[1:]:

--- a/docs/field-definition.ipynb
+++ b/docs/field-definition.ipynb
@@ -17,6 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "\n",
     "import discretisedfield as df\n",
     "\n",
     "p1 = (-50, -50, -50)\n",
@@ -170,7 +172,7 @@
     }
    ],
    "source": [
-    "(field.array == 1.23).all()"
+    "np.array_equiv(field.array, 1.23)"
    ]
   },
   {
@@ -666,7 +668,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/mesh-basics.ipynb
+++ b/docs/mesh-basics.ipynb
@@ -361,7 +361,7 @@
     {
      "data": {
       "text/plain": [
-       "<generator object Mesh.indices at 0x7f187843d3c0>"
+       "<generator object Mesh.indices at 0x7f466521ee30>"
       ]
      },
      "execution_count": 14,
@@ -555,7 +555,7 @@
     {
      "data": {
       "text/plain": [
-       "[1e-08, 3.0000000000000004e-08, 5e-08, 7e-08, 9e-08]"
+       "array([1.e-08, 3.e-08, 5.e-08, 7.e-08, 9.e-08])"
       ]
      },
      "execution_count": 20,
@@ -564,7 +564,7 @@
     }
    ],
    "source": [
-    "list(mesh.cells.x)"
+    "mesh.cells.x"
    ]
   },
   {
@@ -575,7 +575,7 @@
     {
      "data": {
       "text/plain": [
-       "[1.25e-08, 3.75e-08]"
+       "array([1.25e-08, 3.75e-08])"
       ]
      },
      "execution_count": 21,
@@ -584,7 +584,7 @@
     }
    ],
    "source": [
-    "list(mesh.cells.y)"
+    "mesh.cells.y"
    ]
   },
   {
@@ -602,7 +602,7 @@
     {
      "data": {
       "text/plain": [
-       "[0.0, 2e-08, 4e-08, 6.000000000000001e-08, 8e-08, 1e-07]"
+       "array([0.e+00, 2.e-08, 4.e-08, 6.e-08, 8.e-08, 1.e-07])"
       ]
      },
      "execution_count": 22,
@@ -611,7 +611,7 @@
     }
    ],
    "source": [
-    "list(mesh.vertices.x)"
+    "mesh.vertices.x"
    ]
   },
   {
@@ -622,7 +622,7 @@
     {
      "data": {
       "text/plain": [
-       "[0.0, 2.5e-08, 5e-08]"
+       "array([0.0e+00, 2.5e-08, 5.0e-08])"
       ]
      },
      "execution_count": 23,
@@ -631,7 +631,7 @@
     }
    ],
    "source": [
-    "list(mesh.vertices.y)"
+    "mesh.vertices.y"
    ]
   },
   {
@@ -1128,7 +1128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.12.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
### **User description**
- [x] rerun tests after merging ubermag/ubermagutil#53


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Updated `datetime` usage to handle deprecation of `utcnow()` in Python 3.12.
- Added `.item()` to convert xarray and numpy values to Python built-in types.
- Converted `mesh.n`, `region.pmin`, and `region.pmax` to lists using `tolist()` method in Jinja2 templates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hdf5.py</strong><dd><code>Update datetime usage to handle deprecation in Python 3.12</code></dd></summary>
<hr>

discretisedfield/io/hdf5.py

<li>Updated <code>utcnow</code> to <code>now</code> with <code>datetime.UTC</code> to handle deprecation in <br>Python 3.12.<br>


</details>


  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/532/files#diff-39def737ba78f85af8f515ef3c1c5602391c99bcb75eaeb189ff4a366cd6d576">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hv.py</strong><dd><code>Ensure compatibility with xarray in resampling function</code>&nbsp; &nbsp; </dd></summary>
<hr>

discretisedfield/plotting/hv.py

<li>Added <code>.item()</code> to convert xarray to Python built-in type before using <br><code>linspace</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/532/files#diff-3e50151dd1046211ca111a090ea920ee499420b5fb3bfa96e04319fc95a90a0c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tools.py</strong><dd><code>Convert numpy values to Python types in count_bps function</code></dd></summary>
<hr>

discretisedfield/tools/tools.py

- Added `.item()` to convert numpy values to Python built-in types.



</details>


  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/532/files#diff-349a1e45e423c5ad6cf127ec9ead646e2f3e60b59c4c8b7df127779aa69df0a7">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mesh.jinja2</strong><dd><code>Convert mesh.n to list in mesh template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

discretisedfield/html/templates/mesh.jinja2

- Converted `mesh.n` to list using `tolist()` method.



</details>


  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/532/files#diff-abba04684845ad82db9eab266083eb89131e0fdd996ca9a6faed98fbae65041e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>region.jinja2</strong><dd><code>Convert region.pmin and region.pmax to list in region template</code></dd></summary>
<hr>

discretisedfield/html/templates/region.jinja2

<li>Converted <code>region.pmin</code> and <code>region.pmax</code> to list using <code>tolist()</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/532/files#diff-db22f8be37d96fc9cf5d95e42c0fd376b7c7c5fd6d626ea3967ca821a2f7ae70">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

