### PR TITLE
added deprecated message for k3d visualisation

### DIFF
--- a/docs/field-k3d-visualisation.ipynb
+++ b/docs/field-k3d-visualisation.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Field visualisation using `k3d`\n",
     "\n",
-    "**Note:** If you experience any problems in plotting with `k3d`, please make sure you run the Jupyter notebook in Google Chrome.\n",
+    "**Note:** The visualisation method using `k3d` is deprecated and will be removed in future versions, please use `PyVista` for visualising fields instead.\n",
+    "\n",
+    "If you experience any problems in plotting with `k3d`, please make sure you run the Jupyter notebook in Google Chrome.\n",
     "\n",
     "There are several ways how a field can be visualised, using:\n",
     "\n",


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Added a deprecation message in the documentation for the `k3d` visualisation method, indicating it will be removed in future versions.
- Recommended using `PyVista` for field visualisation instead of `k3d`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field-k3d-visualisation.ipynb</strong><dd><code>Add deprecation notice for `k3d` visualisation method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/field-k3d-visualisation.ipynb

<li>Added a deprecation note for the <code>k3d</code> visualisation method.<br> <li> Suggested using <code>PyVista</code> as an alternative for field visualisation.<br>


</details>


  </td>
  <td><a href="https://github.com/ubermag/discretisedfield/pull/534/files#diff-305e3eea79a0ae5670a5981db5b516884e43e811d83aa4559508e6c5f04ba959">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information